### PR TITLE
Fix encoding error on special_tokens

### DIFF
--- a/pr_agent/algo/token_handler.py
+++ b/pr_agent/algo/token_handler.py
@@ -21,4 +21,4 @@ class TokenHandler:
         return system_prompt_tokens + user_prompt_tokens
 
     def count_tokens(self, patch: str) -> int:
-        return len(self.encoder.encode(patch))
+        return len(self.encoder.encode(patch, disallowed_special=()))


### PR DESCRIPTION
## Description 
Force special tokens to be encoded as natural text when using `tiktoken`