### PR TITLE
Adding numbered hunks and code suggestions feature

### DIFF
--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -108,3 +108,78 @@ def handle_patch_deletions(patch: str, original_file_content_str: str,
                 logging.info(f"Processing file: {file_name}, hunks were deleted")
             patch = patch_new
     return patch
+
+
+def convert_to_hunks_with_lines_numbers(patch: str, file) -> str:
+    # toDO: (maybe remove '-' and '+' from the beginning of the line)
+    """
+    ## src/file.ts
+--new hunk--
+881        line1
+882        line2
+883        line3
+884        line4
+885        line6
+886        line7
+887 +      line8
+888 +      line9
+889        line10
+890        line11
+...
+--old hunk--
+        line1
+        line2
+-       line3
+-       line4
+        line5
+        line6
+           ...
+
+    """
+    patch_with_lines_str = f"## {file.filename}\n"
+    import re
+    patch_lines = patch.splitlines()
+    RE_HUNK_HEADER = re.compile(
+        r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[ ]?(.*)")
+    new_content_lines = []
+    old_content_lines = []
+    match = None
+    start1, size1, start2, size2 = -1, -1, -1, -1
+    for line in patch_lines:
+        if 'no newline at end of file' in line.lower():
+            continue
+
+        if line.startswith('@@'):
+            match = RE_HUNK_HEADER.match(line)
+            if match and new_content_lines:  # found a new hunk, split the previous lines
+                if new_content_lines:
+                    patch_with_lines_str += '\n--new hunk--\n'
+                    for i, line_new in enumerate(new_content_lines):
+                        patch_with_lines_str += f"{start2 + i} {line_new}\n"
+                if old_content_lines:
+                    patch_with_lines_str += '--old hunk--\n'
+                    for i, line_old in enumerate(old_content_lines):
+                        patch_with_lines_str += f"{line_old}\n"
+                new_content_lines = []
+                old_content_lines = []
+            start1, size1, start2, size2 = map(int, match.groups()[:4])
+        elif line.startswith('+'):
+            new_content_lines.append(line)
+        elif line.startswith('-'):
+            old_content_lines.append(line)
+        else:
+            new_content_lines.append(line)
+            old_content_lines.append(line)
+
+    # finishing last hunk
+    if match and new_content_lines:
+        if new_content_lines:
+            patch_with_lines_str += '\n--new hunk--\n'
+            for i, line_new in enumerate(new_content_lines):
+                patch_with_lines_str += f"{start2 + i} {line_new}\n"
+        if old_content_lines:
+            patch_with_lines_str += '\n--old hunk--\n'
+            for i, line_old in enumerate(old_content_lines):
+                patch_with_lines_str += f"{line_old}\n"
+
+    return patch_with_lines_str.strip()

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os
 
+from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 from pr_agent.tools.pr_description import PRDescription
 from pr_agent.tools.pr_questions import PRQuestions
 from pr_agent.tools.pr_reviewer import PRReviewer
@@ -12,7 +13,8 @@ def run():
     parser = argparse.ArgumentParser(description='AI based pull request analyzer')
     parser.add_argument('--pr_url', type=str, help='The URL of the PR to review', required=True)
     parser.add_argument('--question', type=str, help='Optional question to ask', required=False)
-    parser.add_argument('--pr_description', action='store_true', help='Optional question to ask', required=False)
+    parser.add_argument('--pr_description', action='store_true', required=False)
+    parser.add_argument('--pr_code_suggestions', action='store_true', required=False)
     args = parser.parse_args()
     logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
     if args.question:
@@ -23,6 +25,10 @@ def run():
         print(f"PR description: {args.pr_url}")
         reviewer = PRDescription(args.pr_url)
         asyncio.run(reviewer.describe())
+    elif args.pr_code_suggestions:
+        print(f"PR code suggestions: {args.pr_url}")
+        reviewer = PRCodeSuggestions(args.pr_url)
+        asyncio.run(reviewer.suggest())
     else:
         print(f"Reviewing PR: {args.pr_url}")
         reviewer = PRReviewer(args.pr_url, cli_mode=True)

--- a/pr_agent/config_loader.py
+++ b/pr_agent/config_loader.py
@@ -12,6 +12,7 @@ settings = Dynaconf(
          "settings/pr_reviewer_prompts.toml",
          "settings/pr_questions_prompts.toml",
          "settings/pr_description_prompts.toml",
+         "settings/pr_code_suggestions_prompts.toml",
          "settings_prod/.secrets.toml"
         ]]
 )

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -38,6 +38,11 @@ class GitProvider(ABC):
         pass
 
     @abstractmethod
+    def publish_code_suggestion(self, body: str, relevant_file: str,
+                                relevant_lines_start: int, relevant_lines_end: int):
+        pass
+
+    @abstractmethod
     def remove_initial_comment(self):
         pass
 

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -106,6 +106,12 @@ class GitLabProvider(GitProvider):
             self.mr.discussions.create({'body': body,
                                         'position': pos_obj})
 
+    def publish_code_suggestion(self, body: str,
+                                relevant_file: str,
+                                relevant_lines_start: int,
+                                relevant_lines_end: int):
+        raise "not implemented yet for gitlab"
+
     def search_line(self, relevant_file, relevant_line_in_file):
         RE_HUNK_HEADER = re.compile(
             r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[ ]?(.*)")

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -8,10 +8,13 @@ verbosity_level=0 # 0,1,2
 require_focused_review=true
 require_tests_review=true
 require_security_review=true
-num_code_suggestions=4
+num_code_suggestions=3
 inline_code_comments = true
 
 [pr_questions]
+
+[pr_code_suggestions]
+num_code_suggestions=4
 
 [github]
 # The type of deployment to create. Valid values are 'app' or 'user'.

--- a/pr_agent/settings/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/pr_code_suggestions_prompts.toml
@@ -1,0 +1,79 @@
+[pr_code_suggestions_prompt]
+system="""You are a language model called CodiumAI-PR-Code-Reviewer.
+Your task is to provide provide meaningfull non-trivial code suggestions to improve the new code in a PR (the '+' lines).
+- Try to give important suggestions like fixing code problems, issues and bugs. As a second priority, provide suggestions for meaningfull code improvements, like performance, vulnerability, modularity, and best practices.
+- Suggestions should refer only to the 'new hunk' code, and focus on improving the new added code lines, with '+'.
+- Provide the exact line number range (inclusive) for each issue.
+- Assume there is additional code in the relevant file that is not included in the diff.
+- Provide up to {{ num_code_suggestions }} code suggestions.
+- Make sure not to provide suggestion repeating modifications already implemented in the new PR code (the '+' lines).
+- Don't output line numbers in the 'improved code' snippets.
+
+You must use the following JSON schema to format your answer:
+```json
+{
+    "Code suggestions": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": {{ num_code_suggestions }},
+      "uniqueItems": "true",
+      "items": {
+        "relevant file": {
+          "type": "string",
+          "description": "the relevant file full path"
+        },
+        "suggestion content": {
+          "type": "string",
+          "description": "a concrete suggestion for meaningfully improving the new PR code."
+        },
+        "existing code": {
+          "type": "string",
+          "description": "a code snippet showing authentic relevant code lines from a 'new hunk' section. It must be continuous, correctly formatted and indented, and without line numbers."
+        },
+        "relevant lines": {
+          "type": "string",
+          "description": "the relevant lines in the 'new hunk' sections, in the format of 'start_line-end_line'. For example: '10-15'. They should be derived from the hunk line numbers, and correspond to the 'existing code' snippet above."
+        },
+        "improved code": {
+          "type": "string",
+          "description": "a new code snippet that can be used to replace the relevant lines in 'new hunk' code. Replacement suggestions should be complete, correctly formatted and indented, and without line numbers."
+        }
+      }
+    }
+}
+```
+
+Example input:
+'
+## src/file1.py
+---new_hunk---
+```
+[new hunk code, annotated with line numbers]
+```
+---old_hunk---
+```
+[old hunk code]
+```
+...
+'
+
+Don't repeat the prompt in the answer, and avoid outputting the 'type' and 'description' fields.
+"""
+
+user="""PR Info:
+Title: '{{title}}'
+Branch: '{{branch}}'
+Description: '{{description}}'
+{%- if language %}
+Main language: {{language}}
+{%- endif %}
+
+
+The PR Diff:
+```
+{{diff}}
+```
+
+Response (should be a valid JSON, and nothing else):
+```json
+"""

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -1,0 +1,127 @@
+import copy
+import json
+import logging
+import textwrap
+
+from jinja2 import Environment, StrictUndefined
+
+from pr_agent.algo.ai_handler import AiHandler
+from pr_agent.algo.pr_processing import get_pr_diff
+from pr_agent.algo.token_handler import TokenHandler
+from pr_agent.algo.utils import convert_to_markdown, try_fix_json
+from pr_agent.config_loader import settings
+from pr_agent.git_providers import get_git_provider, GithubProvider
+from pr_agent.git_providers.git_provider import get_main_pr_language
+
+
+class PRCodeSuggestions:
+    def __init__(self, pr_url: str, cli_mode=False):
+
+        self.git_provider = get_git_provider()(pr_url)
+        self.main_language = get_main_pr_language(
+            self.git_provider.get_languages(), self.git_provider.get_files()
+        )
+        self.ai_handler = AiHandler()
+        self.patches_diff = None
+        self.prediction = None
+        self.cli_mode = cli_mode
+        self.vars = {
+            "title": self.git_provider.pr.title,
+            "branch": self.git_provider.get_pr_branch(),
+            "description": self.git_provider.get_pr_description(),
+            "language": self.main_language,
+            "diff": "",  # empty diff for initial calculation
+            'num_code_suggestions': settings.pr_code_suggestions.num_code_suggestions,
+        }
+        self.token_handler = TokenHandler(self.git_provider.pr,
+                                          self.vars,
+                                          settings.pr_code_suggestions_prompt.system,
+                                          settings.pr_code_suggestions_prompt.user)
+
+    async def suggest(self):
+        assert type(self.git_provider) == GithubProvider, "Only Github is supported for now"
+
+        logging.info('Generating code suggestions for PR...')
+        if settings.config.publish_review:
+            self.git_provider.publish_comment("Preparing review...", is_temporary=True)
+        logging.info('Getting PR diff...')
+
+        # we are using extended hunk with line numbers for code suggestions
+        self.patches_diff = get_pr_diff(self.git_provider,
+                                        self.token_handler,
+                                        add_line_numbers_to_hunks=True,
+                                        disable_extra_lines=True)
+
+        logging.info('Getting AI prediction...')
+        self.prediction = await self._get_prediction()
+        logging.info('Preparing PR review...')
+        data = self._prepare_pr_code_suggestions()
+        if settings.config.publish_review:
+            logging.info('Pushing PR review...')
+            self.git_provider.remove_initial_comment()
+            logging.info('Pushing inline code comments...')
+            self.push_inline_code_suggestions(data)
+
+
+    async def _get_prediction(self):
+        variables = copy.deepcopy(self.vars)
+        variables["diff"] = self.patches_diff  # update diff
+        environment = Environment(undefined=StrictUndefined)
+        system_prompt = environment.from_string(settings.pr_code_suggestions_prompt.system).render(variables)
+        user_prompt = environment.from_string(settings.pr_code_suggestions_prompt.user).render(variables)
+        if settings.config.verbosity_level >= 2:
+            logging.info(f"\nSystem prompt:\n{system_prompt}")
+            logging.info(f"\nUser prompt:\n{user_prompt}")
+        model = settings.config.model
+        response, finish_reason = await self.ai_handler.chat_completion(model=model, temperature=0.2,
+                                                                        system=system_prompt, user=user_prompt)
+
+        return response
+
+    def _prepare_pr_code_suggestions(self) -> str:
+        review = self.prediction.strip()
+        data = None
+        try:
+            data = json.loads(review)
+        except json.decoder.JSONDecodeError:
+            if settings.config.verbosity_level >= 2:
+                logging.info(f"Could not parse json response: {review}")
+            data = try_fix_json(review)
+        return data
+
+    def push_inline_code_suggestions(self, data):
+        for d in data['Code suggestions']:
+            if settings.config.verbosity_level >= 2:
+                logging.info(f"suggestion: {d}")
+            relevant_file = d['relevant file'].strip()
+            relevant_lines_str = d['relevant lines'].strip()
+            relevant_lines_start = int(relevant_lines_str.split('-')[0])  # absolute position
+            relevant_lines_end = int(relevant_lines_str.split('-')[-1])
+            content = d['suggestion content']
+            existing_code_snippet = d['existing code']
+            new_code_snippet = d['improved code']
+
+            if new_code_snippet:
+                try:  # dedent code snippet
+                    self.diff_files = self.git_provider.diff_files if self.git_provider.diff_files else self.git_provider.get_diff_files()
+                    original_initial_line = None
+                    for file in self.diff_files:
+                        if file.filename.strip() == relevant_file:
+                            original_initial_line = file.head_file.splitlines()[relevant_lines_start - 1]
+                            break
+                    if original_initial_line:
+                        suggested_initial_line = new_code_snippet.splitlines()[0]
+                        original_initial_spaces = len(original_initial_line) - len(original_initial_line.lstrip())
+                        suggested_initial_spaces = len(suggested_initial_line) - len(suggested_initial_line.lstrip())
+                        delta_spaces = original_initial_spaces - suggested_initial_spaces
+                        if delta_spaces > 0:
+                            new_code_snippet = textwrap.indent(new_code_snippet, delta_spaces * " ").rstrip('\n')
+                except Exception as e:
+                    if settings.config.verbosity_level >= 2:
+                        logging.info(f"Could not dedent code snippet for file {relevant_file}, error: {e}")
+
+            body = f"**Suggestion:** {content}\n```suggestion\n" + new_code_snippet + "\n```"
+            success = self.git_provider.publish_code_suggestion(body=body,
+                                                      relevant_file=relevant_file,
+                                                      relevant_lines_start=relevant_lines_start,
+                                                      relevant_lines_end=relevant_lines_end)

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -35,7 +35,7 @@ class PRDescription:
         self.prediction = None
 
     async def describe(self):
-        logging.info('Answering a PR question...')
+        logging.info('Generating a PR description...')
         if settings.config.publish_review:
             self.git_provider.publish_comment("Preparing pr description...", is_temporary=True)
         logging.info('Getting PR diff...')


### PR DESCRIPTION
Type of PR:
**Enhancement**

___
PR Description:
**This PR introduces a new feature that allows the conversion of hunks in a patch to numbered hunks, and the generation of code suggestions for a PR. It also includes the necessary changes to support this feature in the Github and Gitlab providers, and updates the CLI and configuration settings accordingly.**

___
PR Main Files Walkthrough:
-`pr_agent/algo/git_patch_processing.py`: Added a new function `convert_to_hunks_with_lines_numbers` that converts a patch to numbered hunks. This function is used to generate more detailed diffs for code suggestions.
-`pr_agent/algo/pr_processing.py`: Updated the `get_pr_diff` function to support the addition of line numbers to hunks. This is used when generating the PR diff for code suggestions.
-`pr_agent/cli.py`: Added a new command line argument `--pr_code_suggestions` to trigger the code suggestions feature.
-`pr_agent/git_providers/git_provider.py`: Added a new abstract method `publish_code_suggestion` to the `GitProvider` base class, which is implemented by the Github and Gitlab providers.
-`pr_agent/git_providers/github_provider.py`: Implemented the `publish_code_suggestion` method for the Github provider.
-`pr_agent/git_providers/gitlab_provider.py`: Implemented the `publish_code_suggestion` method for the Gitlab provider, but it currently raises a 'not implemented yet' exception.
-`pr_agent/tools/pr_code_suggestions.py`: Added a new class `PRCodeSuggestions` that handles the generation and publishing of code suggestions for a PR.
-`pr_agent/settings/configuration.toml`: Updated the configuration settings to include a new setting for the number of code suggestions to generate.
-`pr_agent/settings/pr_code_suggestions_prompts.toml`: Added a new file that contains the prompts for the code suggestions feature.
