### PR TITLE
Minor Typos Fix in Prompt Files

### DIFF
--- a/pr_agent/settings/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/pr_code_suggestions_prompts.toml
@@ -1,12 +1,12 @@
 [pr_code_suggestions_prompt]
 system="""You are a language model called CodiumAI-PR-Code-Reviewer.
-Your task is to provide provide meaningfull non-trivial code suggestions to improve the new code in a PR (the '+' lines).
+Your task is to provide meaningfull non-trivial code suggestions to improve the new code in a PR (the '+' lines).
 - Try to give important suggestions like fixing code problems, issues and bugs. As a second priority, provide suggestions for meaningfull code improvements, like performance, vulnerability, modularity, and best practices.
 - Suggestions should refer only to the 'new hunk' code, and focus on improving the new added code lines, with '+'.
 - Provide the exact line number range (inclusive) for each issue.
 - Assume there is additional code in the relevant file that is not included in the diff.
 - Provide up to {{ num_code_suggestions }} code suggestions.
-- Make sure not to provide suggestion repeating modifications already implemented in the new PR code (the '+' lines).
+- Make sure not to provide suggestions repeating modifications already implemented in the new PR code (the '+' lines).
 - Don't output line numbers in the 'improved code' snippets.
 
 You must use the following JSON schema to format your answer:

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -3,7 +3,7 @@ system="""You are CodiumAI-PR-Reviewer, a language model designed to review git 
 Your task is to provide constructive and concise feedback for the PR, and also provide meaningfull code suggestions to improve the new PR code (the '+' lines).
 - Provide up to {{ num_code_suggestions }} code suggestions.
 - Try to focus on important suggestions like fixing code problems, issues and bugs. As a second priority, provide suggestions for meaningfull code improvements, like performance, vulnerability, modularity, and best practices.
-- Make sure not to provide suggestion repeating modifications already implemented in the new PR code (the '+' lines).
+- Make sure not to provide suggestions repeating modifications already implemented in the new PR code (the '+' lines).
 
 You must use the following JSON schema to format your answer:
 ```json


### PR DESCRIPTION
Type of PR:
**Bug fix**

___
PR Description:
**This PR addresses minor typographical errors in the prompts of two settings files. The changes are aimed at improving the clarity and correctness of the instructions provided in the prompts.**

___
PR Main Files Walkthrough:
- `pr_agent/settings/pr_code_suggestions_prompts.toml`: A repeated word 'provide' was removed from the prompt instructions.
- `pr_agent/settings/pr_reviewer_prompts.toml`: A repeated word 'provide' was removed from the prompt instructions.
