### PR TITLE
Removal of Duplicate Function Across Git Providers

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -61,9 +61,6 @@ class BitbucketProvider:
     def get_title(self):
         return self.pr.title
 
-    def get_description(self):
-        return self.pr.body
-
     def get_languages(self):
         languages = {self._get_repo().get_data('language'): 0}
         return languages

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -134,9 +134,6 @@ class GithubProvider(GitProvider):
     def get_title(self):
         return self.pr.title
 
-    def get_description(self):
-        return self.pr.body
-
     def get_languages(self):
         languages = self._get_repo().get_languages()
         return languages

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -171,9 +171,6 @@ class GitLabProvider(GitProvider):
     def get_title(self):
         return self.mr.title
 
-    def get_description(self):
-        return self.mr.description
-
     def get_languages(self):
         languages = self.gl.projects.get(self.id_project).languages()
         return languages

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -23,7 +23,7 @@ class PRDescription:
         self.vars = {
             "title": self.git_provider.pr.title,
             "branch": self.git_provider.get_pr_branch(),
-            "description": self.git_provider.get_description(),
+            "description": self.git_provider.get_pr_description(),
             "language": self.main_pr_language,
             "diff": "",  # empty diff for initial calculation
         }

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -22,7 +22,7 @@ class PRQuestions:
         self.vars = {
             "title": self.git_provider.pr.title,
             "branch": self.git_provider.get_pr_branch(),
-            "description": self.git_provider.get_description(),
+            "description": self.git_provider.get_pr_description(),
             "language": self.main_pr_language,
             "diff": "",  # empty diff for initial calculation
             "questions": self.question_str,


### PR DESCRIPTION
Type of PR:
**Refactoring**

___
PR Description:
**This PR removes the 'get_description' function from the Bitbucket, GitHub, and GitLab providers. Instead, it uses the 'get_pr_description' function in the 'pr_description.py' and 'pr_questions.py' files. This change aims to reduce code duplication and improve maintainability.**

___
PR Main Files Walkthrough:
-`bitbucket_provider.py`: Removed the 'get_description' function.
-`github_provider.py`: Removed the 'get_description' function.
-`gitlab_provider.py`: Removed the 'get_description' function.
-`pr_description.py`: Replaced the 'get_description' function call with 'get_pr_description'.
-`pr_questions.py`: Replaced the 'get_description' function call with 'get_pr_description'.
