### PR TITLE
Add Option to Control Comment Publishing Progress

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -50,6 +50,9 @@ class GithubProvider(GitProvider):
         # self.pr.create_issue_comment(pr_comment)
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
+        if is_temporary and not settings.config.publish_output_progress:
+            logging.debug(f"Skipping publish_comment for temporary comment: {pr_comment}")
+            return
         response = self.pr.create_issue_comment(pr_comment)
         if hasattr(response, "user") and hasattr(response.user, "login"):
             self.github_user_id = response.user.login
@@ -140,7 +143,7 @@ class GithubProvider(GitProvider):
 
     def remove_initial_comment(self):
         try:
-            for comment in self.pr.comments_list:
+            for comment in getattr(self.pr, 'comments_list', []):
                 if comment.is_temporary:
                     comment.delete()
         except Exception as e:

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -2,6 +2,7 @@
 model="gpt-4-0613"
 git_provider="github"
 publish_output=true
+publish_output_progress=true
 verbosity_level=0 # 0,1,2
 
 [pr_reviewer]


### PR DESCRIPTION
PR Type:
**Enhancement**

___
PR Description:
**This PR introduces a new configuration option to control the publishing of progress comments in the PR. This option can be toggled on or off in the configuration file. Additionally, the PR includes some minor refactoring in the comment handling logic.**

___
PR Main Files Walkthrough:
-`pr_agent/git_providers/github_provider.py`: Added a check for the new `publish_output_progress` setting before publishing a temporary comment. Also, modified the `remove_initial_comment` method to use `getattr` for safer attribute access.
-`pr_agent/settings/configuration.toml`: Added a new configuration option `publish_output_progress` to control whether progress comments should be published or not.
