### PR TITLE
Fix TypeError for GitlabProvider

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -260,3 +260,6 @@ class GitLabProvider(GitProvider):
 
     def publish_labels(self, labels):
         pass
+
+    def publish_inline_comments(self, comments: list[dict]):
+        pass


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "/Users/sambolgert/Documents/workspace/pr-agent/pr_agent/cli.py", line 75, in <module>
    run()
  File "/Users/sambolgert/Documents/workspace/pr-agent/pr_agent/cli.py", line 55, in run
    reviewer = PRCodeSuggestions(args.pr_url)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sambolgert/Documents/workspace/pr-agent/pr_agent/tools/pr_code_suggestions.py", line 20, in __init__
    self.git_provider = get_git_provider()(pr_url)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Can't instantiate abstract class GitLabProvider with abstract method publish_inline_comments
```