### PR TITLE
Fix for GitLab Paginator in GitLab Provider

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -49,7 +49,7 @@ class GitLabProvider(GitProvider):
     def _set_merge_request(self, merge_request_url: str):
         self.id_project, self.id_mr = self._parse_merge_request_url(merge_request_url)
         self.mr = self._get_merge_request()
-        self.last_diff = self.mr.diffs.list()[-1]
+        self.last_diff = self.mr.diffs.list(all=True)[-1]
 
     def _get_pr_file_content(self, file_path: str, branch: str) -> str:
         try:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -49,7 +49,7 @@ class GitLabProvider(GitProvider):
     def _set_merge_request(self, merge_request_url: str):
         self.id_project, self.id_mr = self._parse_merge_request_url(merge_request_url)
         self.mr = self._get_merge_request()
-        self.last_diff = self.mr.diffs.list(all=True)[-1]
+        self.last_diff = self.mr.diffs.list(get_all=True)[-1]
 
     def _get_pr_file_content(self, file_path: str, branch: str) -> str:
         try:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -11,6 +11,8 @@ from pr_agent.config_loader import settings
 from ..algo.language_handler import is_valid_file
 from .git_provider import EDIT_TYPE, FilePatchInfo, GitProvider
 
+logger = logging.getLogger()
+
 
 class GitLabProvider(GitProvider):
 
@@ -49,7 +51,12 @@ class GitLabProvider(GitProvider):
     def _set_merge_request(self, merge_request_url: str):
         self.id_project, self.id_mr = self._parse_merge_request_url(merge_request_url)
         self.mr = self._get_merge_request()
-        self.last_diff = self.mr.diffs.list(get_all=True)[-1]
+        try:
+            self.last_diff = self.mr.diffs.list(get_all=True)[-1]
+        except IndexError as e:
+            logger.error(f"Could not get diff for merge request {self.id_mr}")
+            raise ValueError(f"Could not get diff for merge request {self.id_mr}") from e
+
 
     def _get_pr_file_content(self, file_path: str, branch: str) -> str:
         try:


### PR DESCRIPTION
PR Type:
**Bug fix**

___
PR Description:
**This PR addresses an issue with the GitLab Provider where it was not correctly handling pagination for merge request diffs. The fix ensures that all diffs are retrieved by passing the 'get_all=True' argument to the 'list' method.**

___
PR Main Files Walkthrough:
-`git_providers/gitlab_provider.py`: The change is made in the '_set_merge_request' method where the 'get_all=True' argument is added to the 'list' method call on 'self.mr.diffs'. This ensures that all diffs are retrieved, not just the ones on the current page.
