### PR TITLE
Minor improvements to describe command

### DIFF
--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -23,7 +23,7 @@ class PRAgent:
             else:
                 await PRReviewer(pr_url, args=args).review()
         elif any(cmd == action for cmd in ["/describe", "/describe_pr"]):
-            await PRDescription(pr_url).describe()
+            await PRDescription(pr_url, args=args).describe()
         elif any(cmd == action for cmd in ["/improve", "/improve_code"]):
             await PRCodeSuggestions(pr_url).suggest()
         elif any(cmd == action for cmd in ["/ask", "/ask_question"]):

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -73,7 +73,7 @@ def _handle_ask_command(pr_url: str, rest: list):
 
 def _handle_describe_command(pr_url: str, rest: list):
     print(f"PR description: {pr_url}")
-    reviewer = PRDescription(pr_url)
+    reviewer = PRDescription(pr_url, args=rest)
     asyncio.run(reviewer.describe())
 
 

--- a/pr_agent/servers/help.py
+++ b/pr_agent/servers/help.py
@@ -1,6 +1,8 @@
 commands_text = "> **/review [-i]**: Request a review of your Pull Request. For an incremental review, which only " \
                 "considers changes since the last review, include the '-i' option.\n" \
-                "> **/describe**: Modify the PR title and description based on the contents of the PR.\n" \
+                "> **/describe [-c]**: Modify the PR title and description based on the contents of the PR. " \
+                "To get the description as comment instead of modifying the PR description, " \
+                "include the '-c' option.\n" \
                 "> **/improve**: Suggest improvements to the code in the PR. " \
                 "These will be provided as pull request comments, ready to commit.\n" \
                 "> **/ask \\<QUESTION\\>**: Pose a question about the PR.\n"

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -14,12 +14,14 @@ from pr_agent.git_providers.git_provider import get_main_pr_language
 
 
 class PRDescription:
-    def __init__(self, pr_url: str):
+    def __init__(self, pr_url: str, args: list = None):
         """
         Initialize the PRDescription object with the necessary attributes and objects for generating a PR description using an AI model.
         Args:
             pr_url (str): The URL of the pull request.
+            args (list, optional): List of arguments passed to the PRDescription class. Defaults to None.
         """
+        self.parse_args(args)
         
         # Initialize the git provider and main PR language
         self.git_provider = get_git_provider()(pr_url)
@@ -51,6 +53,22 @@ class PRDescription:
         self.patches_diff = None
         self.prediction = None
 
+    def parse_args(self, args: List[str]) -> None:
+        """
+        Parse the arguments passed to the PRDescription class and set the 'publish_description_as_comment' attribute accordingly.
+
+        Args:
+            args: A list of arguments passed to the PRReviewer class.
+
+        Returns:
+            None
+        """
+        self.publish_description_as_comment = settings.pr_description.publish_description_as_comment
+        if args and len(args) >= 1:
+            arg = args[0]
+            if arg == "-c":
+                self.publish_description_as_comment = True
+
     async def describe(self):
         """
         Generates a PR description using an AI model and publishes it to the PR.
@@ -66,7 +84,7 @@ class PRDescription:
         
         if settings.config.publish_output:
             logging.info('Pushing answer...')
-            if settings.pr_description.publish_description_as_comment:
+            if self.publish_description_as_comment:
                 self.git_provider.publish_comment(markdown_text)
             else:
                 self.git_provider.publish_description(pr_title, pr_body)

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -160,11 +160,11 @@ class PRDescription:
         # Iterate over the remaining dictionary items and append the key and value to 'pr_body' in a markdown format,
         # except for the items containing the word 'walkthrough'
         for key, value in data.items():
-            pr_body += f"{key}:\n"
+            pr_body += f"## {key}:\n"
             if 'walkthrough' in key.lower():
                 pr_body += f"{value}\n"
             else:
-                pr_body += f"**{value}**\n\n___\n"
+                pr_body += f"{value}\n\n___\n"
 
         if settings.config.verbosity_level >= 2:
             logging.info(f"title:\n{title}\n{pr_body}")


### PR DESCRIPTION
Just thought these might be useful:
1. Added option to used the describe command with -c instead of setting the configuration `publish_description_as_comment`. Can be useful when you just want to see what the PR-Agent says but you don't want it to edit your description (maybe you already have a very detailed one but you just want to get a second opinion)
2. The markdown styling of describe as comment vs describe as PR description was a little different. I changed the styling of the PR description to match the one of the comment because I think having an entire paragraph in **bold** is messier than the clean header+paragraph style of the description as comment.