### PR TITLE
fix TypeError when iterating discussion_messages

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -250,7 +250,7 @@ class PRReviewer:
         if self.is_answer:
             discussion_messages = self.git_provider.get_issue_comments()
 
-            for message in reversed(discussion_messages):
+            for message in discussion_messages.reversed:
                 if "Questions to better understand the PR:" in message.body:
                     question_str = message.body
                 elif '/answer' in message.body:


### PR DESCRIPTION
# Observed Behavior

When `pr-agent` is reviewing a long list of messages, a TypeError is thrown on the line

```python
for message in reversed(discussion_messages):
```

# Expected behavior

Should iterate over `discussion_messages` and not crash.

# Reproduction steps

1. Install `codium-ai/pr-agent` using the GitHub Action method
2. Create a Pull Request
3. Add lots of discussion messages. This specific PR had 25 comments.
4. Execute `/reflect`
5. Give some `/answers`
6. Bang, exception thrown 💥
 
When reviewing the PyGithub library, the recommend an alternate syntax for iterating a paginated list in reverse.

https://github.com/PyGithub/PyGithub/blob/v1.59.0/github/PaginatedList.py#L122-L125

```
    If you want to iterate in reversed order, just do::

        for repo in user.get_repos().reversed:
            print(repo.name)
```

And here's a copy of the actual traceback

```
Traceback (most recent call last):
  File "/app/pr_agent/servers/github_action_runner.py", line 68, in <module>
    asyncio.run(run_action())
  File "/usr/local/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/app/pr_agent/servers/github_action_runner.py", line 64, in run_action
    await PRAgent().handle_request(pr_url, body)
  File "/app/pr_agent/agent/pr_agent.py", line 19, in handle_request
    await PRReviewer(pr_url, is_answer=True).review()
  File "/app/pr_agent/tools/pr_reviewer.py", line 49, in __init__
    answer_str, question_str = self._get_user_answers()
  File "/app/pr_agent/tools/pr_reviewer.py", line 253, in _get_user_answers
    for message in reversed(discussion_messages):
TypeError: object of type 'PaginatedList' has no len()
```