### PR TITLE
Use commit messages in PR tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2023-08-02
+
+### Enhanced
+- Updated several tools in the `pr_agent` package to use commit messages in their functionality.
+- Commit messages are now retrieved and stored in the `vars` dictionary for each tool.
+- Added a section to display the commit messages in the prompts of various tools.
+
 ## 2023-08-01
 2023-08-01
 

--- a/pr_agent/settings/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/pr_code_suggestions_prompts.toml
@@ -73,6 +73,11 @@ Description: '{{description}}'
 {%- if language %}
 Main language: {{language}}
 {%- endif %}
+{%- if commit_messages_str %}
+
+Commit messages:
+{{commit_messages_str}}
+{%- endif %}
 
 
 The PR Diff:

--- a/pr_agent/settings/pr_information_from_user_prompts.toml
+++ b/pr_agent/settings/pr_information_from_user_prompts.toml
@@ -21,6 +21,11 @@ Description: '{{description}}'
 {%- if language %}
 Main language: {{language}}
 {%- endif %}
+{%- if commit_messages_str %}
+
+Commit messages:
+{{commit_messages_str}}
+{%- endif %}
 
 
 The PR Git Diff:

--- a/pr_agent/settings/pr_questions_prompts.toml
+++ b/pr_agent/settings/pr_questions_prompts.toml
@@ -13,6 +13,11 @@ Description: '{{description}}'
 {%- if language %}
 Main language: {{language}}
 {%- endif %}
+{%- if commit_messages_str %}
+
+Commit messages:
+{{commit_messages_str}}
+{%- endif %}
 
 
 The PR Git Diff:

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -135,6 +135,11 @@ Description: '{{description}}'
 {%- if language %}
 Main language: {{language}}
 {%- endif %}
+{%- if commit_messages_str %}
+
+Commit messages:
+{{commit_messages_str}}
+{%- endif %}
 
 {%- if question_str %}
 ######

--- a/pr_agent/settings/pr_update_changelog_prompts.toml
+++ b/pr_agent/settings/pr_update_changelog_prompts.toml
@@ -19,6 +19,11 @@ Description: '{{description}}'
 {%- if language %}
 Main language: {{language}}
 {%- endif %}
+{%- if commit_messages_str %}
+
+Commit messages:
+{{commit_messages_str}}
+{%- endif %}
 
 
 The PR Diff:

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -34,6 +34,7 @@ class PRCodeSuggestions:
             "diff": "",  # empty diff for initial calculation
             "num_code_suggestions": get_settings().pr_code_suggestions.num_code_suggestions,
             "extra_instructions": get_settings().pr_code_suggestions.extra_instructions,
+            "commit_messages_str": self.git_provider.get_commit_messages(),
         }
         self.token_handler = TokenHandler(self.git_provider.pr,
                                           self.vars,

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -27,7 +27,6 @@ class PRDescription:
         self.main_pr_language = get_main_pr_language(
             self.git_provider.get_languages(), self.git_provider.get_files()
         )
-        commit_messages_str = self.git_provider.get_commit_messages()
 
         # Initialize the AI handler
         self.ai_handler = AiHandler()
@@ -40,7 +39,7 @@ class PRDescription:
             "language": self.main_pr_language,
             "diff": "",  # empty diff for initial calculation
             "extra_instructions": get_settings().pr_description.extra_instructions,
-            "commit_messages_str": commit_messages_str
+            "commit_messages_str": self.git_provider.get_commit_messages()
         }
     
         # Initialize the token handler

--- a/pr_agent/tools/pr_information_from_user.py
+++ b/pr_agent/tools/pr_information_from_user.py
@@ -24,6 +24,7 @@ class PRInformationFromUser:
             "description": self.git_provider.get_pr_description(),
             "language": self.main_pr_language,
             "diff": "",  # empty diff for initial calculation
+            "commit_messages_str": self.git_provider.get_commit_messages(),
         }
         self.token_handler = TokenHandler(self.git_provider.pr,
                                           self.vars,

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -27,6 +27,7 @@ class PRQuestions:
             "language": self.main_pr_language,
             "diff": "",  # empty diff for initial calculation
             "questions": self.question_str,
+            "commit_messages_str": self.git_provider.get_commit_messages(),
         }
         self.token_handler = TokenHandler(self.git_provider.pr,
                                           self.vars,

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -59,6 +59,7 @@ class PRReviewer:
             'question_str': question_str,
             'answer_str': answer_str,
             "extra_instructions": get_settings().pr_reviewer.extra_instructions,
+            "commit_messages_str": self.git_provider.get_commit_messages(),
         }
 
         self.token_handler = TokenHandler(

--- a/pr_agent/tools/pr_update_changelog.py
+++ b/pr_agent/tools/pr_update_changelog.py
@@ -38,6 +38,7 @@ class PRUpdateChangelog:
             "changelog_file_str": self.changelog_file_str,
             "today": date.today(),
             "extra_instructions": get_settings().pr_update_changelog.extra_instructions,
+            "commit_messages_str": self.git_provider.get_commit_messages(),
         }
         self.token_handler = TokenHandler(self.git_provider.pr,
                                           self.vars,


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR updates several tools in the `pr_agent` package to use the commit messages in their functionality. The commit messages are now retrieved and stored in the `vars` dictionary for each tool.

___
## PR Main Files Walkthrough:
- `pr_agent/tools/pr_code_suggestions.py`: Added the `commit_messages_str` key to the `vars` dictionary.
- `pr_agent/tools/pr_description.py`: Removed the `commit_messages_str` variable and added the `commit_messages_str` key to the `vars` dictionary.
- `pr_agent/tools/pr_information_from_user.py`: Added the `commit_messages_str` key to the `vars` dictionary.
- `pr_agent/tools/pr_questions.py`: Added the `commit_messages_str` key to the `vars` dictionary.
- `pr_agent/tools/pr_reviewer.py`: Added the `commit_messages_str` key to the `vars` dictionary.
- `pr_agent/tools/pr_update_changelog.py`: Added the `commit_messages_str` key to the `vars` dictionary.
- `pr_agent/settings/pr_code_suggestions_prompts.toml`: Added a section to display the commit messages.
- `pr_agent/settings/pr_information_from_user_prompts.toml`: Added a section to display the commit messages.
- `pr_agent/settings/pr_questions_prompts.toml`: Added a section to display the commit messages.
- `pr_agent/settings/pr_reviewer_prompts.toml`: Added a section to display the commit messages.
- `pr_agent/settings/pr_update_changelog_prompts.toml`: Added a section to display the commit messages.
