### PR TITLE
Handling edge case for hunks in git patch processing

### DIFF
--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -41,7 +41,11 @@ def extend_patch(original_file_str, patch_str, num_lines) -> str:
                         extended_patch_lines.extend(
                             original_lines[start1 + size1 - 1:start1 + size1 - 1 + num_lines])
 
-                    start1, size1, start2, size2 = map(int, match.groups()[:4])
+                    try:
+                        start1, size1, start2, size2 = map(int, match.groups()[:4])
+                    except:  # '@@ -0,0 +1 @@' case
+                        start1, size1, size2 = map(int, match.groups()[:3])
+                        start2 = 0
                     section_header = match.groups()[4]
                     extended_start1 = max(1, start1 - num_lines)
                     extended_size1 = size1 + (start1 - extended_start1) + num_lines
@@ -198,7 +202,12 @@ def convert_to_hunks_with_lines_numbers(patch: str, file) -> str:
                         patch_with_lines_str += f"{line_old}\n"
                 new_content_lines = []
                 old_content_lines = []
-            start1, size1, start2, size2 = map(int, match.groups()[:4])
+            try:
+                start1, size1, start2, size2 = map(int, match.groups()[:4])
+            except: # '@@ -0,0 +1 @@' case
+                start1, size1, size2 = map(int, match.groups()[:3])
+                start2 = 0
+
         elif line.startswith('+'):
             new_content_lines.append(line)
         elif line.startswith('-'):


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses an edge case in the git patch processing algorithm. The edge case occurs when the patch string is '@@ -0,0 +1 @@', which previously caused an error. The PR adds exception handling to prevent this error.

___
## PR Main Files Walkthrough:
- `pr_agent/algo/git_patch_processing.py`: Added exception handling in two places where the patch string is parsed. If the parsing fails due to the edge case, it now defaults to a specific value.
