### PR TITLE
Added title and description to `/describe` command prompt

### DIFF
--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -34,9 +34,10 @@ Don't repeat the prompt in the answer, and avoid outputting the 'type' and 'desc
 """
 
 user="""PR Info:
+Title: '{{title}}'
 Branch: '{{branch}}'
+Description: '{{description}}'
 {%- if language %}
-
 Main language: {{language}}
 {%- endif %}
 {%- if commit_messages_str %}


### PR DESCRIPTION
It can sometimes be beneficial for the agent to read the original PR description (as written by the user) to have a better understanding of the context.   The code diff alone is great to understand __what__ is happening in the PR, but from the description the agent can understand the __why__. We often use the description to describe the bug that prompted the fix, the requirement that lead to this feature, or even some form of design for the PR. All of these can give the agent better context to write a better description on its own.