### PR TITLE
fix bug: add PyYAML & starlette_context in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ aiohttp~=3.8.4
 atlassian-python-api==3.39.0
 GitPython~=3.1.32
 litellm~=0.1.351
+PyYAML~=3.09
+starlette_context~=0.1.5


### PR DESCRIPTION
Recently PyYAML was added to the project.
It is missing in the `requirements.txt`

Should fix issue #189 