### PR TITLE
Correcting CLI and README Descriptions and Fixing Requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ CodiumAI `PR-Agent` is an open-source tool aiming to help developers review pull
 |       | Incremental PR Review |   :white_check_mark:    |      |         |
 
 Examples for invoking the different tools via the CLI:
-- **Review**:       python cli.py --pr-url=<pr_url>  review
-- **Describe**:     python cli.py --pr-url=<pr_url>  describe
-- **Improve**:      python cli.py --pr-url=<pr_url>  improve
-- **Ask**:          python cli.py --pr-url=<pr_url>  ask "Write me a poem about this PR"
-- **Reflect**:      python cli.py --pr-url=<pr_url>  reflect
-- **Update Changelog**:      python cli.py --pr-url=<pr_url>  update_changelog
+- **Review**:       python cli.py --pr_url=<pr_url>  review
+- **Describe**:     python cli.py --pr_url=<pr_url>  describe
+- **Improve**:      python cli.py --pr_url=<pr_url>  improve
+- **Ask**:          python cli.py --pr_url=<pr_url>  ask "Write me a poem about this PR"
+- **Reflect**:      python cli.py --pr_url=<pr_url>  reflect
+- **Update Changelog**:      python cli.py --pr_url=<pr_url>  update_changelog
 
 "<pr_url>" is the url of the relevant PR (for example: https://github.com/Codium-ai/pr-agent/pull/50).
 

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -10,13 +10,13 @@ from pr_agent.config_loader import get_settings
 def run(inargs=None):
     parser = argparse.ArgumentParser(description='AI based pull request analyzer', usage=
 """\
-Usage: cli.py --pr-url <URL on supported git hosting service> <command> [<args>].
+Usage: cli.py --pr-url=<URL on supported git hosting service> <command> [<args>].
 For example:
-- cli.py --pr-url=... review
-- cli.py --pr-url=... describe
-- cli.py --pr-url=... improve
-- cli.py --pr-url=... ask "write me a poem about this PR"
-- cli.py --pr-url=... reflect
+- cli.py --pr_url=... review
+- cli.py --pr_url=... describe
+- cli.py --pr_url=... improve
+- cli.py --pr_url=... ask "write me a poem about this PR"
+- cli.py --pr_url=... reflect
 
 Supported commands:
 review / review_pr - Add a review that includes a summary of the PR and specific suggestions for improvement.
@@ -27,7 +27,7 @@ reflect - Ask the PR author questions about the PR.
 update_changelog - Update the changelog based on the PR's contents.
 
 To edit any configuration parameter from 'configuration.toml', just add -config_path=<value>.
-For example: '- cli.py --pr-url=... review --pr_reviewer.extra_instructions="focus on the file: ..."'
+For example: 'python cli.py --pr_url=... review --pr_reviewer.extra_instructions="focus on the file: ..."'
 """)
     parser.add_argument('--pr_url', type=str, help='The URL of the PR to review', required=True)
     parser.add_argument('command', type=str, help='The', choices=commands, default='review')

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ GitPython~=3.1.32
 litellm~=0.1.351
 PyYAML==6.0
 starlette-context==0.3.6
+litellm~=0.1.351

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ GitPython~=3.1.32
 litellm~=0.1.351
 PyYAML==6.0
 starlette-context==0.3.6
-litellm~=0.1.351


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR corrects the command line interface (CLI) and README descriptions for the `pr_url` parameter, changing it from `--pr-url` to `--pr_url`. Additionally, it removes a duplicate entry in the requirements.txt file.

___
## PR Main Files Walkthrough:
`pr_agent/cli.py`: Updated the usage and help descriptions for the `pr_url` parameter in the CLI.
`README.md`: Updated the examples for invoking the different tools via the CLI, correcting the `pr_url` parameter.
`requirements.txt`: Removed a duplicate entry.
