### PR TITLE
Remove extra blank line in help message

### DIFF
--- a/pr_agent/servers/help.py
+++ b/pr_agent/servers/help.py
@@ -2,7 +2,7 @@ commands_text = "> **/review [-i]**: Request a review of your Pull Request. For 
                 "considers changes since the last review, include the '-i' option.\n" \
                 "> **/describe**: Modify the PR title and description based on the contents of the PR.\n" \
                 "> **/improve**: Suggest improvements to the code in the PR. \n" \
-                "> **/ask \\<QUESTION\\>**: Pose a question about the PR.\n\n" \
+                "> **/ask \\<QUESTION\\>**: Pose a question about the PR.\n" \
                 "> **/update_changelog**: Update the changelog based on the PR's contents.\n\n" \
                 ">To edit any configuration parameter from **configuration.toml**, add --config_path=new_value\n" \
                 ">For example: /review --pr_reviewer.extra_instructions=\"focus on the file: ...\" \n" \


### PR DESCRIPTION
Will change this:  
![image](https://github.com/Codium-ai/pr-agent/assets/33152084/3c990724-b66b-41f8-824c-7b7d6be6c491)

To this:  
![image](https://github.com/Codium-ai/pr-agent/assets/33152084/9a22e815-7ffa-4966-942f-fdd91a897b4d)

Unless this was intentional, in which case feel free to just toss this PR away.