### PR TITLE
Contents read-only permission needed by /review -i

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -128,6 +128,7 @@ Allowing you to automate the review process on your private or public repositori
      - Pull requests: Read & write
      - Issue comment: Read & write
      - Metadata: Read-only
+     - Contents: Read-only
    - Set the following events:
      - Issue comment
      - Pull request


### PR DESCRIPTION
The `Contents` permission is missing from the install doc for creating a GitHub App but this permission is needed to read commits for use with `/review -i`.