### PR TITLE
Implement get_repo_settings for BitbucketProvider

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,6 +92,7 @@ pip install -r requirements.txt
 
 ```
 cp pr_agent/settings/.secrets_template.toml pr_agent/settings/.secrets.toml
+chmod 600 pr_agent/settings/.secrets.toml
 # Edit .secrets.toml file
 ```
 

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -93,6 +93,13 @@ class BitbucketProvider:
     def get_issue_comments(self):
         raise NotImplementedError("Bitbucket provider does not support issue comments yet")
 
+    def get_repo_settings(self):
+        try:
+            contents = self.repo_obj.get_contents(".pr_agent.toml", ref=self.pr.head.sha).decoded_content
+            return contents
+        except Exception:
+            return ""
+
     def add_eyes_reaction(self, issue_comment_id: int) -> Optional[int]:
         return True
 
@@ -104,7 +111,7 @@ class BitbucketProvider:
         parsed_url = urlparse(pr_url)
         
         if 'bitbucket.org' not in parsed_url.netloc:
-            raise ValueError("The provided URL is not a valid GitHub URL")
+            raise ValueError("The provided URL is not a valid Bitbucket URL")
 
         path_parts = parsed_url.path.strip('/').split('/')
         

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -90,6 +90,10 @@ class GitProvider(ABC):
         pass
 
     @abstractmethod
+    def get_repo_settings(self):
+        pass
+
+    @abstractmethod
     def add_eyes_reaction(self, issue_comment_id: int) -> Optional[int]:
         pass
 

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -1,0 +1,10 @@
+from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
+
+
+class TestBitbucketProvider:
+    def test_parse_pr_url(self):
+        url = "https://bitbucket.org/WORKSPACE_XYZ/MY_TEST_REPO/pull-requests/321"
+        workspace_slug, repo_slug, pr_number = BitbucketProvider._parse_pr_url(url)
+        assert workspace_slug == "WORKSPACE_XYZ"
+        assert repo_slug == "MY_TEST_REPO"
+        assert pr_number == 321


### PR DESCRIPTION
This PR fixes an error in the BitbucketProvider class.

I was testing out the pr-agent for Bitbucket (the CLI version) and I got the following error:

> `AttributeError: 'BitbucketProvider' object has no attribute 'get_repo_settings'`

This PR fixes that error, and after this code was in place, the pr-agent was able to successfully comment on my Bitbucket PR.

Other modifications:

- added get_repo_settings() as an abstract method in the parent GitProvider class, since it is used in the GitHub and GitLab classes also.
- added a unit test for the BitbucketProvider URL parser.
- added a `chmod` command on the `.secrets.toml` in the `INSTALL.md` instructions.

(Note: Ignore PR 204 and PR 205)