### PR TITLE
Fix bitbucket ask issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ CodiumAI `PR-Agent` is an open-source tool aiming to help developers review pull
 |-------|---------------------------------------------|:------:|:------:|:---------:|
 | TOOLS | Review                                      |   :white_check_mark:    |   :white_check_mark:    |   :white_check_mark:       |
 |       | ⮑ Inline review                             |   :white_check_mark:    |   :white_check_mark:    |           |
-|       | Ask                                         |   :white_check_mark:    |   :white_check_mark:    |           |
+|       | Ask                                         |   :white_check_mark:    |   :white_check_mark:    |   :white_check_mark:
 |       | Auto-Description                            |   :white_check_mark:    |  :white_check_mark:      |           |
 |       | Improve Code                                |   :white_check_mark:    |   :white_check_mark:    |           |
 |       | Reflect and Review                          |   :white_check_mark:    |                         |           |

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -26,6 +26,13 @@ class BitbucketProvider:
         if pr_url:
             self.set_pr(pr_url)
 
+    def get_repo_settings(self):
+        try:
+            contents = self.repo_obj.get_contents(".pr_agent.toml", ref=self.pr.head.sha).decoded_content
+            return contents
+        except Exception:
+            return ""
+
     def is_supported(self, capability: str) -> bool:
         if capability in ['get_issue_comments', 'create_inline_comment', 'publish_inline_comments', 'get_labels']:
             return False


### PR DESCRIPTION
I noticed that the `bitbucket_provider.py` file is missing the `get_repo_settings()` function, which is causing some issues with its proper functioning. I've gone ahead and added the necessary `get_repo_settings()` function to `bitbucket_provider.py`, and as a result, the functionality has been restored.

To verify the changes, I used Docker commands to run the project, and I'm pleased to report that ask command is now working as expected. Additionally, I've successfully tested this setup and observed that it's now capable of adding comments in the PRs.

Here's an example of the `ask` command that triggers the desired action:
![Image](https://github.com/Codium-ai/pr-agent/assets/42999707/1c3777d3-a07a-4f3a-8328-c051f9d55bd7)

As a result of this, you can see the corresponding comment in Bitbucket:
![Image](https://github.com/Codium-ai/pr-agent/assets/42999707/dc72709c-7c3b-4251-b44c-ce17b048c854)

These changes should significantly enhance the functionality of the project. Please review the modifications at your earliest convenience and let me know if there are any further adjustments required.


