### PR TITLE
Publish comment when improve has no suggestions

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -93,6 +93,10 @@ class PRCodeSuggestions:
 
     def push_inline_code_suggestions(self, data):
         code_suggestions = []
+
+        if not data['Code suggestions']:
+            return self.git_provider.publish_comment('🎉 The PR looks good and there is nothing to suggest!')
+
         for d in data['Code suggestions']:
             try:
                 if get_settings().config.verbosity_level >= 2:

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -95,7 +95,7 @@ class PRCodeSuggestions:
         code_suggestions = []
 
         if not data['Code suggestions']:
-            return self.git_provider.publish_comment('🎉 The PR looks good and there is nothing to suggest!')
+            return self.git_provider.publish_comment('No suggestions found to improve this PR.')
 
         for d in data['Code suggestions']:
             try:


### PR DESCRIPTION
When `/improve` does not return any suggestions, currently it is unclear if the request failed or there were no suggestions.

This change adds a comment on the PR when no suggestions are returned. 

I don't feel strongly about the specific wording of the comment, but I think it is helpful to post something when there are no suggestions.