### PR TITLE
Safe parse key value in config override

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -245,19 +245,27 @@ def update_settings_from_args(args: List[str]) -> List[str]:
             arg = arg.strip()
             if arg.startswith('--'):
                 arg = arg.strip('-').strip()
-                vals = arg.split('=')
+                vals = arg.split('=', 1)
                 if len(vals) != 2:
                     logging.error(f'Invalid argument format: {arg}')
                     other_args.append(arg)
                     continue
-                key, value = vals
-                key = key.strip().upper()
-                value = value.strip()
+                key, value = _fix_key_value(*vals)
                 get_settings().set(key, value)
                 logging.info(f'Updated setting {key} to: "{value}"')
             else:
                 other_args.append(arg)
     return other_args
+
+
+def _fix_key_value(key: str, value: str):
+    key = key.strip().upper()
+    value = value.strip()
+    try:
+        value = yaml.safe_load(value)
+    except Exception as e:
+        logging.error(f"Failed to parse YAML for config override {key}={value}", exc_info=e)
+    return key, value
 
 
 def load_yaml(review_text: str) -> dict:


### PR DESCRIPTION
I noticed this bug when trying to run some command with `--config.verbosity_level=3` and got this error:
```log
File "/home/vcap/app/pr_agent/agent/pr_agent.py", line 81, in handle_request
await command2class[action](pr_url, args=args).run()
File "/home/vcap/app/pr_agent/tools/pr_code_suggestions.py", line 50, in run
await retry_with_fallback_models(self._prepare_prediction)
File "/home/vcap/app/pr_agent/algo/pr_processing.py", line 217, in retry_with_fallback_models
return await f(model)
File "/home/vcap/app/pr_agent/tools/pr_code_suggestions.py", line 68, in _prepare_prediction
self.prediction = await self._get_prediction(model)
File "/home/vcap/app/pr_agent/tools/pr_code_suggestions.py", line 76, in _get_prediction
if get_settings().config.verbosity_level >= 2:
TypeError: '>=' not supported between instances of 'str' and 'int'
```

This fix uses `yaml.safe_load` for robust parsing of the `value` string:
```python
>>> yaml.safe_load("3")
3
>>> yaml.safe_load("'3'")
'3'
>>> yaml.safe_load("'some string'")
'some string'
>>> yaml.safe_load("some other string")
'some other string'
>>> yaml.safe_load("true")
True
>>> yaml.safe_load("False")
False
```