### PR TITLE
Remove duplicate get_repo_settings() in bitbucket_provider

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -168,13 +168,6 @@ class BitbucketProvider:
     def get_issue_comments(self):
         raise NotImplementedError("Bitbucket provider does not support issue comments yet")
 
-    def get_repo_settings(self):
-        try:
-            contents = self.repo_obj.get_contents(".pr_agent.toml", ref=self.pr.head.sha).decoded_content
-            return contents
-        except Exception:
-            return ""
-
     def add_eyes_reaction(self, issue_comment_id: int) -> Optional[int]:
         return True
 


### PR DESCRIPTION
* I believe that @sarbjitsinghgrewal and I submitted PRs to fix a missing get_repo_settings() function in bitbucket_provider, at the same time. We added the function to different parts of the file, so that is how the git merge (and us humans) missed the duplicate.
* In this PR, I am removing my copy that I added in commit f82b962