### PR TITLE
adding permissions to the GitHub Actions section of INSTALL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,6 +54,10 @@ on:
 jobs:
   pr_agent_job:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
     name: Run pr agent on every pull request, respond to user comments
     steps:
       - name: PR Agent action step
@@ -72,6 +76,10 @@ on:
 jobs:
   pr_agent_job:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
     name: Run pr agent on every pull request, respond to user comments
     steps:
       - name: PR Agent action step


### PR DESCRIPTION
Could we consider adding permissions to the GitHub Actions section?
I've noticed that this has been a point of confusion for some users, as evidenced by questions in our Discord channel and GitHub issues. Some folks may even be discouraged to the point of not seeking help. I believe adding permissions could significantly improve the user experience. What are your thoughts?