### PR TITLE
Try to refine the prompt to prevent split line ranges that give bad suggestions

### DIFF
--- a/pr_agent/settings/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/pr_code_suggestions_prompts.toml
@@ -68,12 +68,17 @@ Code suggestions:
       type: string
       description: |-
         a code snippet showing the relevant code lines from a '__new hunk__' section.
-        It must be continuous, correctly formatted and indented, and without line numbers.
-    relevant lines:
-      type: string
+        It must be contiguous, correctly formatted and indented, and without line numbers.
+    relevant lines start:
+      type: integer
       description: |-
-        the relevant lines from a '__new hunk__' section, in the format of 'start_line-end_line'.
-        For example: '10-15'. They should be derived from the hunk line numbers, and correspond to the 'existing code' snippet above.
+        The relevant line number from a '__new hunk__' section where the suggestion starts (inclusive).
+        Should be derived from the hunk line numbers, and correspond to the 'existing code' snippet above.
+    relevant lines end:
+      type: integer
+      description: |-
+        The relevant line number from a '__new hunk__' section where the suggestion ends (inclusive).
+        Should be derived from the hunk line numbers, and correspond to the 'existing code' snippet above.
     improved code:
       type: string
       description: |-
@@ -90,7 +95,8 @@ Code suggestions:
         Add a docstring to func1()
     existing code: |-
         def func1():
-    relevant lines: '12-12'
+    relevant lines start: 12
+    relevant lines end: 12
     improved code: |-
         ...
 ```

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -113,11 +113,8 @@ class PRCodeSuggestions:
                 if get_settings().config.verbosity_level >= 2:
                     logging.info(f"suggestion: {d}")
                 relevant_file = d['relevant file'].strip()
-                relevant_lines_str = d['relevant lines'].strip()
-                if ',' in relevant_lines_str:  # handling 'relevant lines': '181, 190' or '178-184, 188-194'
-                    relevant_lines_str = relevant_lines_str.split(',')[0]
-                relevant_lines_start = int(relevant_lines_str.split('-')[0])  # absolute position
-                relevant_lines_end = int(relevant_lines_str.split('-')[-1])
+                relevant_lines_start = int(d['relevant lines start'])  # absolute position
+                relevant_lines_end = int(d['relevant lines end'])
                 content = d['suggestion content']
                 new_code_snippet = d['improved code']
 


### PR DESCRIPTION
I noticed that in some cases the `/improve` command will try to repeat the same suggestion for several code locations in the same file, for example - something like this:
```json
"Code suggestions": [
  {
    "relevant file": "pr_agent/git_providers/codecommit_client.py",
    "suggestion content": "Add type hints to the method signatures.",
    "existing code": "def get_differences(self, repo_name: int, destination_commit: str, source_commit: str):\n\ndef get_file(self, repo_name: str, file_path: str, sha_hash: str, optional: bool = False):\n\ndef get_pr(self, pr_number: int):\n\ndef publish_comment(self, repo_name: str, pr_number: int, destination_commit: str, source_commit: str, comment: str):",
    "relevant lines": "64-67, 100-103, 136-139, 167-170",
    "improved code": "def get_differences(self, repo_name: str, destination_commit: str, source_commit: str) -> List[CodeCommitDifferencesResponse]:\n\ndef get_file(self, repo_name: str, file_path: str, sha_hash: str, optional: bool = False) -> str:\n\ndef get_pr(self, pr_number: int) -> CodeCommitPullRequestResponse:\n\ndef publish_comment(self, repo_name: str, pr_number: int, destination_commit: str, source_commit: str, comment: str) -> None:"
  },
  ...
]
```

This creates some ugly and wrong suggestions in the PR. For example:  

![image](https://github.com/Codium-ai/pr-agent/assets/33152084/b023c6fd-9442-43f8-a1bb-9137e4b4da08)

I tried adding more "constraints" in the prompt to force it to split such suggestions in separate list items.