### PR TITLE
bump litellm version - prevent default logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ atlassian-python-api==3.39.0
 GitPython~=3.1.32
 PyYAML==6.0
 starlette-context==0.3.6
-litellm~=0.1.445
+litellm~=0.1.504
 boto3~=1.28.25
 google-cloud-storage==2.10.0
 ujson==5.8.0


### PR DESCRIPTION
will add additional testing if the initial version bump pr looks good. 

We're also adding testing on our end to debugging is opt-in only. https://github.com/BerriAI/litellm/blob/main/litellm/tests/test_litedebugger_integration.py