### PR TITLE
Fix #254

### DIFF
--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -86,11 +86,11 @@ class GitProvider(ABC):
     def get_pr_description_full(self) -> str:
         pass
 
-    def get_pr_description(self) -> str:
+    def get_pr_description(self, *, full: bool = True) -> str:
         from pr_agent.config_loader import get_settings
         from pr_agent.algo.pr_processing import clip_tokens
         max_tokens = get_settings().get("CONFIG.MAX_DESCRIPTION_TOKENS", None)
-        description = self.get_pr_description_full()
+        description = self.get_pr_description_full() if full else self.get_user_description()
         if max_tokens:
             return clip_tokens(description, max_tokens)
         return description

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -36,7 +36,7 @@ class PRDescription:
         self.vars = {
             "title": self.git_provider.pr.title,
             "branch": self.git_provider.get_pr_branch(),
-            "description": self.git_provider.get_pr_description(),
+            "description": self.git_provider.get_pr_description(full=False),
             "language": self.main_pr_language,
             "diff": "",  # empty diff for initial calculation
             "extra_instructions": get_settings().pr_description.extra_instructions,


### PR DESCRIPTION
The issue is caused by using the full description in the prompt for the describe command, which includes all the description generated by the previous invocation of the command.  
For the describe command prompt, only the original user description is needed, and anything else generated by the command itself is counter-productive.

The fix is implemented by taking just the original user description when constructing the describe command prompt, but leaving the rest of the prompts unchanged. (For example, the prompt for the review command can actually benefit from having the agent's generated description in the prompt along with the user description, to serve as a summary of the PR).

These are all the locations that call `get_pr_description`. If you think any of them should use just the original user description, let me know and I'll change them as well.
<img width="890" alt="image" src="https://github.com/Codium-ai/pr-agent/assets/33152084/e0f7548c-95f5-4e7d-b17b-8db97a67cfb5">

@mrT23 @KalleV FYI