### PR TITLE
implement 'improve' command for CodeCommit

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ See the [usage guide](./Usage.md) for instructions how to run the different tool
 | TOOLS | Review                                      |   :white_check_mark:    |   :white_check_mark:    |   :white_check_mark:       |   :white_check_mark:    |   :white_check_mark:    |
 |       | Ask                                         |   :white_check_mark:    |   :white_check_mark:    |   :white_check_mark:          |   :white_check_mark:          | :white_check_mark:
 |       | Auto-Description                            |   :white_check_mark:    |   :white_check_mark:    |           |   :white_check_mark:    |   :white_check_mark:    |
-|       | Improve Code                                |   :white_check_mark:    |   :white_check_mark:    |           |          |          |
-|       | ⮑ Extended                             |   :white_check_mark:    |   :white_check_mark:    |           |          |          |
+|       | Improve Code                                |   :white_check_mark:    |   :white_check_mark:    |           |   :white_check_mark:    |          |
+|       | ⮑ Extended                             |   :white_check_mark:    |   :white_check_mark:    |           |   :white_check_mark:    |          |
 |       | Reflect and Review                          |   :white_check_mark:    |                         |           |          |   :white_check_mark:    |
 |       | Update CHANGELOG.md                         |   :white_check_mark:    |                         |           |          |          |
 |       |                                             |        |        |      |      |      |

--- a/tests/unittest/test_codecommit_client.py
+++ b/tests/unittest/test_codecommit_client.py
@@ -125,7 +125,7 @@ class TestCodeCommitProvider:
             }
         }
 
-        pr = api.get_pr(321)
+        pr = api.get_pr("my_test_repo", 321)
 
         assert pr.title == "My PR"
         assert pr.description == "My PR description"


### PR DESCRIPTION
## PR Type:

Enhancement

___

## PR Description:

This PR implements the 'improve' command for CodeCommit.
- Implements the 'publish_code_suggestions()' function, which is used by the 'improve' command, by adding the ability to annotate comments by file and line number
    - Note that AWS CodeCommit is not as feature-rich as the GitHub site. for example, you cannot highlight a range of line numbers in a file... you can only specify the starting line number for a comment
- Improves error handling when talking to AWS API by adding more specific error messages

___

## PR Main Files Walkthrough:

`pr_agent/git_providers/codecommit_client.py`: Added more specific error messages for various exceptions. Added the ability to annotate comments with file and line information. Also, added the 'repo_name' parameter to the 'get_pr' method to provide a more specific error message.

`pr_agent/git_providers/codecommit_provider.py`: Implemented the 'publish_code_suggestions' method to publish code suggestions for each file. Added logging messages for unsupported features.

`tests/unittest/test_codecommit_client.py`: Updated the 'get_pr' method call in the test to include the 'repo_name' parameter.

`README.md`: Updated the feature matrix to add the 'improve' command for CodeCommit.