### PR TITLE
feat: run analysis also on ready_for_review, synchronize events

### DIFF
--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -50,7 +50,7 @@ async def run_action():
     # Handle pull request event
     if GITHUB_EVENT_NAME == "pull_request":
         action = event_payload.get("action")
-        if action in ["opened", "reopened"]:
+        if action in ["opened", "reopened", "synchronize", "ready_for_review"]:
             pr_url = event_payload.get("pull_request", {}).get("url")
             if pr_url:
                 await PRReviewer(pr_url).run()

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -50,7 +50,7 @@ async def run_action():
     # Handle pull request event
     if GITHUB_EVENT_NAME == "pull_request":
         action = event_payload.get("action")
-        if action in ["opened", "reopened", "synchronize", "ready_for_review"]:
+        if action in ["opened", "reopened", "ready_for_review"]:
             pr_url = event_payload.get("pull_request", {}).get("url")
             if pr_url:
                 await PRReviewer(pr_url).run()


### PR DESCRIPTION
this allows running the codium ai pr analysys on the "ready for review" event, and not run the AI analysis
if the PR is marked as a draft PR.

```
"jobs":
  "pr_agent_job":
    "container":
      "image": "alpine:3.18.3"
    "if": "${{ github.event.pull_request.draft == false }}"
    "steps":
    - "env":
        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
        "OPENAI_KEY": "${{ secrets.OPENAI_KEY }}"
      "name": "PR Agent action step"
      "uses": "Codium-ai/pr-agent@main"
"name": "codium-ai"
"on":
  "issue_comment": {}
  "pull_request":
    "types":
    - "opened"
    - "reopened"
    - "synchronize"
    - "ready_for_review"
```

essentially the analysis can be used in more contexts. if anyone doesn't want this he/she should use more restrictive triggers.

we essentially wanted to exclude draft prs, but have the AI run on the `ready_for_review` PR event