### PR TITLE
Integrate OpenLLMetry to support agent runs tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.egg-info/
 build/
 review.md
+litellm_uuid.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ dist/
 *.egg-info/
 build/
 review.md
-litellm_uuid.txt

--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -3,6 +3,8 @@ import os
 import shlex
 import tempfile
 
+from traceloop.sdk import Traceloop
+
 from pr_agent.algo.utils import update_settings_from_args
 from pr_agent.config_loader import get_settings
 from pr_agent.git_providers import get_git_provider
@@ -39,6 +41,10 @@ class PRAgent:
         pass
 
     async def handle_request(self, pr_url, request, notify=None) -> bool:
+        Traceloop.init(app_name="pr_agent")
+        # To track multiple processing of the same PR together
+        Traceloop.set_correlation_id(pr_url)
+
         # First, apply repo specific settings if exists
         if get_settings().config.use_repo_settings_file:
             repo_settings_file = None

--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -41,9 +41,12 @@ class PRAgent:
         pass
 
     async def handle_request(self, pr_url, request, notify=None) -> bool:
-        Traceloop.init(app_name="pr_agent")
-        # To track multiple processing of the same PR together
-        Traceloop.set_correlation_id(pr_url)
+        if (get_settings().config.tracing):
+            Traceloop.init(app_name="pr_agent")
+            # To track multiple processing of the same PR together
+            Traceloop.set_correlation_id(pr_url)
+        else:
+            os.environ["TRACELOOP_SUPPRESS_WARNINGS"] = "true"
 
         # First, apply repo specific settings if exists
         if get_settings().config.use_repo_settings_file:

--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -7,6 +7,7 @@ import traceback
 from typing import Any, Callable, List, Tuple
 
 from github import RateLimitExceededException
+from traceloop.sdk.decorators import task
 
 from pr_agent.algo import MAX_TOKENS
 from pr_agent.algo.git_patch_processing import convert_to_hunks_with_lines_numbers, extend_patch, handle_patch_deletions
@@ -23,6 +24,8 @@ OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD = 1000
 OUTPUT_BUFFER_TOKENS_HARD_THRESHOLD = 600
 PATCH_EXTRA_LINES = 3
 
+
+@task(name="get_pr_diff")
 def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler, model: str,
                 add_line_numbers_to_hunks: bool = False, disable_extra_lines: bool = False) -> str:
     """
@@ -58,7 +61,7 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler, model: s
 
     # generate a standard diff string, with patch extension
     patches_extended, total_tokens, patches_extended_tokens = pr_generate_extended_diff(pr_languages, token_handler,
-                                                               add_line_numbers_to_hunks)
+                                                                                        add_line_numbers_to_hunks)
 
     # if we are under the limit, return the full diff
     if total_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD < MAX_TOKENS[model]:

--- a/pr_agent/settings/.secrets_template.toml
+++ b/pr_agent/settings/.secrets_template.toml
@@ -50,7 +50,3 @@ personal_access_token = ""
 [bitbucket]
 # Bitbucket personal bearer token
 bearer_token = ""
-
-[tracing]
-# Set the following to the API KEY for your Traceloop account
-TRACELOOP_API_KEY = ""

--- a/pr_agent/settings/.secrets_template.toml
+++ b/pr_agent/settings/.secrets_template.toml
@@ -50,3 +50,7 @@ personal_access_token = ""
 [bitbucket]
 # Bitbucket personal bearer token
 bearer_token = ""
+
+[tracing]
+# Set the following to the API KEY for your Traceloop account
+TRACELOOP_API_KEY = ""

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -11,6 +11,9 @@ ai_timeout=180
 max_description_tokens = 500
 max_commits_tokens = 500
 secret_provider="google_cloud_storage"
+# Set the following to enable tracing with OpenTelemetry to your observability provider (Datadog, etc.)
+# See https://traceloop.com/docs/python-sdk/introduction for instructions how to config the tracer
+tracing=false
 
 [pr_reviewer] # /review #
 require_focused_review=false

--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -3,6 +3,7 @@ import logging
 import textwrap
 from typing import List, Dict
 from jinja2 import Environment, StrictUndefined
+from traceloop.sdk.decorators import aworkflow
 
 from pr_agent.algo.ai_handler import AiHandler
 from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models, get_pr_multi_diffs
@@ -13,6 +14,7 @@ from pr_agent.git_providers import BitbucketProvider, get_git_provider
 from pr_agent.git_providers.git_provider import get_main_pr_language
 
 
+@aworkflow(name="pr_code_suggestions", method_name="run")
 class PRCodeSuggestions:
     def __init__(self, pr_url: str, cli_mode=False, args: list = None):
 

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -4,6 +4,7 @@ import logging
 from typing import List, Tuple
 
 from jinja2 import Environment, StrictUndefined
+from traceloop.sdk.decorators import aworkflow
 
 from pr_agent.algo.ai_handler import AiHandler
 from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models
@@ -14,6 +15,7 @@ from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.git_provider import get_main_pr_language
 
 
+@aworkflow(name="pr_description", method_name="run")
 class PRDescription:
     def __init__(self, pr_url: str, args: list = None):
         """

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -2,6 +2,7 @@ import copy
 import logging
 
 from jinja2 import Environment, StrictUndefined
+from traceloop.sdk.decorators import aworkflow
 
 from pr_agent.algo.ai_handler import AiHandler
 from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models
@@ -11,6 +12,7 @@ from pr_agent.git_providers import get_git_provider
 from pr_agent.git_providers.git_provider import get_main_pr_language
 
 
+@aworkflow(name="pr_questions", method_name="run")
 class PRQuestions:
     def __init__(self, pr_url: str, args=None):
         question_str = self.parse_args(args)

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -6,6 +6,7 @@ from typing import List, Tuple
 
 import yaml
 from jinja2 import Environment, StrictUndefined
+from traceloop.sdk.decorators import aworkflow
 from yaml import SafeLoader
 
 from pr_agent.algo.ai_handler import AiHandler
@@ -19,6 +20,7 @@ from pr_agent.git_providers.git_provider import IncrementalPR, get_main_pr_langu
 from pr_agent.servers.help import actions_help_text, bot_help_text
 
 
+@aworkflow(name="pr_reviewer", method_name="run")
 class PRReviewer:
     """
     The PRReviewer class is responsible for reviewing a pull request and generating feedback using an AI model.

--- a/pr_agent/tools/pr_update_changelog.py
+++ b/pr_agent/tools/pr_update_changelog.py
@@ -5,6 +5,7 @@ from time import sleep
 from typing import Tuple
 
 from jinja2 import Environment, StrictUndefined
+from traceloop.sdk.decorators import aworkflow
 
 from pr_agent.algo.ai_handler import AiHandler
 from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models
@@ -16,6 +17,7 @@ from pr_agent.git_providers.git_provider import get_main_pr_language
 CHANGELOG_LINES = 50
 
 
+@aworkflow(name="pr_update_changelog", method_name="run")
 class PRUpdateChangelog:
     def __init__(self, pr_url: str, cli_mode=False, args=None):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ google-cloud-storage==2.10.0
 ujson==5.8.0
 azure-devops==7.1.0b3
 msrest==0.7.1
+traceloop-sdk~=0.0.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ google-cloud-storage==2.10.0
 ujson==5.8.0
 azure-devops==7.1.0b3
 msrest==0.7.1
-traceloop-sdk~=0.0.36
+traceloop-sdk~=0.0.39

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ google-cloud-storage==2.10.0
 ujson==5.8.0
 azure-devops==7.1.0b3
 msrest==0.7.1
-traceloop-sdk~=0.0.34
+traceloop-sdk~=0.0.36

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ azure-devops==7.1.0b3
 msrest==0.7.1
 pinecone-client
 pinecone-datasets @ git+https://github.com/mrT23/pinecone-datasets.git@main
-traceloop-sdk~=0.0.39
+traceloop-sdk~=0.0.40


### PR DESCRIPTION
Fixes #214 

Sorry for the dup with #292, had some issues with my fork which closed the original PR. Posting here my reply for the motivation behind this:

I've opened https://github.com/Codium-ai/pr-agent/issues/214 as I wanted to connect traces from runs of PR-Agent to [Honeycomb](https://honeycomb.io/). This is why I suggested in https://github.com/Codium-ai/pr-agent/issues/214 that we instrument PR-Agent with [OpenTelemetry](https://opentelemetry.io/), which is an open standard for reporting logs, metrics and traces from production systems. The great thing about this standard - the data can be piped to any observability system like Datadog, Sentry, Honeycomb, New Relic and others.
We're releasing a new open source SDK next month called [OpenLLMetry](https://github.com/traceloop/openllmetry) that extends OpenTelemetry to support instrumentation for LLM calls. We've also built an SDK to make it easy for devs to instrument and use it in their apps - which is what I used here.
The annotations are only there to enrich the traces, and can potentially be removed (though this will reduce the overall visibility IMO).
So I think the SDK can be super useful to anyone looking to use or develop PR-Agent, similar to other Gen-AI OSS projects that are also adopting OpenLLMetry these days.

Example run exported to [Honeycomb](https://honeycomb.io) - 

<img width="1267" alt="Screenshot 2023-09-07 at 23 28 44" src="https://github.com/Codium-ai/pr-agent/assets/4224692/28eb7d77-2345-4f37-82b6-d26d06752459">
