### PR TITLE
Adding get_pr_id method to Git Providers

### DIFF
--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -127,6 +127,9 @@ class GitProvider(ABC):
     def get_commit_messages(self):
         pass
 
+    def get_pr_id(self):
+        return ""
+
 def get_main_pr_language(languages, files) -> str:
     """
     Get the main language of the commit. Return an empty string if cannot determine.

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -446,3 +446,10 @@ class GithubProvider(GitProvider):
                 logging.info(f"Failed adding line link, error: {e}")
 
         return ""
+
+    def get_pr_id(self):
+        try:
+            pr_id = f"{self.repo}/{self.pr_num}"
+            return pr_id
+        except:
+            return ""

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -382,6 +382,7 @@ class GitLabProvider(GitProvider):
 
     def get_pr_id(self):
         try:
-            return str(self.pr.id)
+            pr_id = self.mr.web_url
+            return pr_id
         except:
             return ""

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -379,3 +379,9 @@ class GitLabProvider(GitProvider):
         if max_tokens:
             commit_messages_str = clip_tokens(commit_messages_str, max_tokens)
         return commit_messages_str
+
+    def get_pr_id(self):
+        try:
+            return str(self.pr.id)
+        except:
+            return ""

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -29,7 +29,7 @@ class PRDescription:
         self.main_pr_language = get_main_pr_language(
             self.git_provider.get_languages(), self.git_provider.get_files()
         )
-        self.pr_id = f"{self.git_provider.repo}/{self.git_provider.pr_num}"
+        self.pr_id = self.git_provider.get_pr_id()
 
         # Initialize the AI handler
         self.ai_handler = AiHandler()


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new method, `get_pr_id`, in the abstract Git Provider class and its implementations (GitHub and GitLab). The method is designed to return the PR ID, which is used in the PR Description tool. This change provides a more consistent and error-tolerant way of fetching the PR ID across different Git providers.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pr_agent/git_providers/git_provider.py`: Added the abstract method `get_pr_id` to the abstract Git Provider class.
`pr_agent/git_providers/github_provider.py`: Implemented the `get_pr_id` method for the GitHub provider, which returns the PR ID in the format "repo/pr_num".
`pr_agent/git_providers/gitlab_provider.py`: Implemented the `get_pr_id` method for the GitLab provider, which returns the PR ID as the web URL of the merge request.
`pr_agent/tools/pr_description.py`: Replaced the direct assignment of `pr_id` with a call to the new `get_pr_id` method from the Git Provider.
</details>
