### PR TITLE
Added 'get_pr_id' function for the CodeCommit provider

### DIFF
--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -235,6 +235,18 @@ class CodeCommitProvider(GitProvider):
     def get_title(self):
         return self.pr.get("title", "")
 
+    def get_pr_id(self):
+        """
+        Returns the PR ID in the format: "repo_name/pr_number".
+        Note: This is an internal identifier for PR-Agent, 
+        and is not the same as the CodeCommit PR identifier.
+        """
+        try:
+            pr_id = f"{self.repo_name}/{self.pr_num}"
+            return pr_id
+        except:
+            return ""
+        
     def get_languages(self):
         """
         Returns a dictionary of languages, containing the percentage of each language used in the PR.

--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -233,7 +233,7 @@ class CodeCommitProvider(GitProvider):
         raise NotImplementedError("CodeCommit provider does not support publishing inline comments yet")
 
     def get_title(self):
-        return self.pr.get("title", "")
+        return self.pr.title
 
     def get_pr_id(self):
         """

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -67,7 +67,7 @@ class PRDescription:
         try:
             logging.info(f"Generating a PR description {self.pr_id}")
             if get_settings().config.publish_output:
-                self.git_provider.publish_comment("Preparing pr description...", is_temporary=True)
+                self.git_provider.publish_comment("Preparing PR description...", is_temporary=True)
 
             await retry_with_fallback_models(self._prepare_prediction)
 

--- a/tests/unittest/test_codecommit_client.py
+++ b/tests/unittest/test_codecommit_client.py
@@ -110,7 +110,7 @@ class TestCodeCommitProvider:
         # Mock the response from the AWS client for get_pull_request method
         api.boto_client.get_pull_request.return_value = {
             "pullRequest": {
-                "pullRequestId": "3",
+                "pullRequestId": "321",
                 "title": "My PR",
                 "description": "My PR description",
                 "pullRequestTargets": [

--- a/tests/unittest/test_codecommit_provider.py
+++ b/tests/unittest/test_codecommit_provider.py
@@ -1,6 +1,8 @@
 import pytest
+from unittest.mock import patch
 from pr_agent.git_providers.codecommit_provider import CodeCommitFile
 from pr_agent.git_providers.codecommit_provider import CodeCommitProvider
+from pr_agent.git_providers.codecommit_provider import PullRequestCCMimic
 from pr_agent.git_providers.git_provider import EDIT_TYPE
 
 
@@ -25,6 +27,21 @@ class TestCodeCommitFile:
 
 
 class TestCodeCommitProvider:
+    def test_get_title(self):
+        # Test that the get_title() function returns the PR title
+        with patch.object(CodeCommitProvider, "__init__", lambda x, y: None):
+            provider = CodeCommitProvider(None)
+            provider.pr = PullRequestCCMimic("My Test PR Title", [])
+            assert provider.get_title() == "My Test PR Title"
+
+    def test_get_pr_id(self):
+        # Test that the get_pr_id() function returns the correct ID
+        with patch.object(CodeCommitProvider, "__init__", lambda x, y: None):
+            provider = CodeCommitProvider(None)
+            provider.repo_name = "my_test_repo"
+            provider.pr_num = 321
+            assert provider.get_pr_id() == "my_test_repo/321"
+
     def test_parse_pr_url(self):
         # Test that the _parse_pr_url() function can extract the repo name and PR number from a CodeCommit URL
         url = "https://us-east-1.console.aws.amazon.com/codesuite/codecommit/repositories/my_test_repo/pull-requests/321"


### PR DESCRIPTION
## PR Type:

Enhancement

___

## PR Description:

- This PR implements the 'get_pr_id' function for the CodeCommit provider.  The 'get_pr_id' function was added in [PR 320](https://github.com/Codium-ai/pr-agent/pull/320)
- Also fixed the 'get_title' function for the CodeCommit provider to get the title from the local class and not from a dictionary
- Added unit tests

___

## PR Main Files Walkthrough:

- `pr_agent/git_providers/codecommit_provider.py`: Added a new method 'get_pr_id' to get the PR ID in the format "repo_name/pr_number". Also, modified the 'get_title' method to directly return the PR title.

- `pr_agent/tools/pr_description.py`: Changed the case of the message from "Preparing pr description..." to "Preparing PR description...".

- `tests/unittest/test_codecommit_client.py`: Updated the mock response for the 'get_pull_request' method so the mock PR ID number matches the number referenced later in the test.  That number is not actually used in the test, but I set the numbers to be the same to avoid confusion later on.

- `tests/unittest/test_codecommit_provider.py`: Added new unit tests for the 'get_title' and 'get_pr_id' methods in the CodeCommit provider
