### PR TITLE
Update Review Guidelines to Exclude Comments

### DIFF
--- a/pr_agent/settings/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/pr_code_suggestions_prompts.toml
@@ -34,7 +34,7 @@ Specific instructions:
 - Provide up to {{ num_code_suggestions }} code suggestions.
 - Prioritize suggestions that address major problems, issues and bugs in the code.
   As a second priority, suggestions should focus on best practices, code readability, maintainability, enhancments, performance, and other aspects.
-  Don't suggest to add docstring or type hints.
+  Don't suggest to add docstring, type hints, or comments.
   Try to provide diverse and insightful suggestions.
 - Suggestions should refer only to code from the '__new hunk__' sections, and focus on new lines of code (lines starting with '+').
   Avoid making suggestions that have already been implemented in the PR code. For example, if you want to add logs, or change a variable to const, or anything else, make sure it isn't already in the '__new hunk__' code.

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -28,7 +28,7 @@ The review should focus on new code added in the PR (lines starting with '+'), a
 - Provide up to {{ num_code_suggestions }} code suggestions.
 - Focus on important suggestions like fixing code problems, issues and bugs. As a second priority, provide suggestions for meaningful code improvements, like performance, vulnerability, modularity, and best practices.
 - Avoid making suggestions that have already been implemented in the PR code. For example, if you want to add logs, or change a variable to const, or anything else, make sure it isn't already in the PR code.
-- Don't suggest to add docstring or type hints.
+- Don't suggest to add docstring, type hints, or comments.
 - Suggestions should focus on improving the new code added in the PR (lines starting with '+')
 {%- endif %}
 


### PR DESCRIPTION
## PR Type:
Documentation

___
## PR Description:
This PR updates the review guidelines in two configuration files. The changes specify that reviewers should not suggest adding docstrings, type hints, or comments to the code. This update is reflected in both 'pr_code_suggestions_prompts.toml' and 'pr_reviewer_prompts.toml' files.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pr_agent/settings/pr_code_suggestions_prompts.toml`: The instructions for code suggestions have been updated to include 'comments' in the list of items that should not be suggested for addition.
`pr_agent/settings/pr_reviewer_prompts.toml`: The review guidelines have been updated to specify that reviewers should not suggest adding docstrings, type hints, or comments.
</details>
