### PR TITLE
update github_actions_runner file for multi commands

### DIFF
--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import os
+import logging
+import sys
 
 from pr_agent.agent.pr_agent import PRAgent
 from pr_agent.config_loader import get_settings
@@ -8,9 +10,11 @@ from pr_agent.git_providers import get_git_provider
 from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 from pr_agent.tools.pr_description import PRDescription
 from pr_agent.tools.pr_reviewer import PRReviewer
+from pr_agent.algo.utils import update_settings_from_args
 
 
 async def run_action():
+    agent = PRAgent()
     # Get environment variables
     GITHUB_EVENT_NAME = os.environ.get('GITHUB_EVENT_NAME')
     GITHUB_EVENT_PATH = os.environ.get('GITHUB_EVENT_PATH')
@@ -52,18 +56,17 @@ async def run_action():
     # Handle pull request event
     if GITHUB_EVENT_NAME == "pull_request":
         action = event_payload.get("action")
-        if action in ["opened", "reopened"]:
+        if action in get_settings().github_workflow.handle_pr_actions:
             pr_url = event_payload.get("pull_request", {}).get("url")
-            if pr_url:
-                auto_review = os.environ.get('github_action.auto_review', None)
-                if auto_review is None or (isinstance(auto_review, str) and auto_review.lower() == 'true'):
-                    await PRReviewer(pr_url).run()
-                auto_describe = os.environ.get('github_action.auto_describe', None)
-                if isinstance(auto_describe, str) and auto_describe.lower() == 'true':
-                    await PRDescription(pr_url).run()
-                auto_improve = os.environ.get('github_action.auto_improve', None)
-                if isinstance(auto_improve, str) and auto_improve.lower() == 'true':
-                    await PRCodeSuggestions(pr_url).run()
+            logging.info(f"Performing review because of event={GITHUB_EVENT_NAME} and action={action}")
+            for command in get_settings().github_workflow.pr_commands:
+                split_command = command.split(" ")
+                command = split_command[0]
+                args = split_command[1:]
+                other_args = update_settings_from_args(args)
+                new_command = ' '.join([command] + other_args)
+                logging.info(f"Performing command: {new_command}")
+                await agent.handle_request(pr_url, new_command)
 
     # Handle issue comment event
     elif GITHUB_EVENT_NAME == "issue_comment":

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -78,6 +78,21 @@ pr_commands = [
     "/auto_review",
 ]
 
+[github_workflow]
+# these toggles allows running the github app from custom deployments
+bot_user = "github-actions[bot]"
+override_deployment_type = true
+# in some deployments it's possible to get duplicate requests if the handling is long,
+# these settings are used to avoid handling duplicate requests.
+duplicate_requests_cache = false
+duplicate_requests_cache_ttl = 60  # in seconds
+# settings for "pull_request" event
+handle_pr_actions = ['opened', 'reopened', 'ready_for_review', 'review_requested', 'synchronize']
+pr_commands = [
+    "/describe --pr_description.add_original_user_description=true --pr_description.keep_original_user_title=true",
+    "/auto_review",
+]
+
 [gitlab]
 # URL to the gitlab service
 url = "https://gitlab.com"


### PR DESCRIPTION
Here is Pull request for Trigger multiple PR-Agent command on GitHub Actions pull request event. In this PR, I update script to support multiple PR-Agent command on GitHub Actions. I reuse logic from github_app.py file. I also add [github_workflow] section in configuration.toml file to handle github_actions_runner file. Now This script running fine and handle multi-commands. Here is screenshot for example:
![image](https://github.com/Codium-ai/pr-agent/assets/42999707/6626b054-d212-4285-b397-d24650a27454)
