### PR TITLE
Add lockb to bad extensions

### DIFF
--- a/pr_agent/settings/language_extensions.toml
+++ b/pr_agent/settings/language_extensions.toml
@@ -53,7 +53,8 @@ default = [
     'xz',
     'zip',
     'zst',
-    'snap'
+    'snap',
+    'lockb'
 ]
 extra = [
     'md',


### PR DESCRIPTION
[Bun](https://github.com/oven-sh/bun) uses `bun.lockb` binary files which cause pr-agent to crash with `UnicodeDecodeError`  when encountered.

E.g:
```
INFO:root:Getting PR diff...
WARNING:root:Cannot decode file bun.lockb or bun.lockb in merge request 1
WARNING:root:Failed to generate prediction with gpt-4: Traceback (most recent call last):
  File "/app/pr_agent/algo/pr_processing.py", line 215, in retry_with_fallback_models
    return await f(model)
  File "/app/pr_agent/tools/pr_reviewer.py", line 131, in _prepare_prediction
    self.patches_diff = get_pr_diff(self.git_provider, self.token_handler, model)
  File "/app/pr_agent/algo/pr_processing.py", line 60, in get_pr_diff
    patches_extended, total_tokens, patches_extended_tokens = pr_generate_extended_diff(pr_languages, token_handler,
  File "/app/pr_agent/algo/pr_processing.py", line 105, in pr_generate_extended_diff
    extended_patch = extend_patch(original_file_content_str, patch, num_lines=PATCH_EXTRA_LINES)
  File "/app/pr_agent/algo/git_patch_processing.py", line 24, in extend_patch
    original_file_str = original_file_str.decode('utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa6 in position 46: invalid start byte
```