### PR TITLE
Azure Devops: Set file content as empty string when azure_devops_client.get_item fails

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -109,7 +109,8 @@ class AzureDevopsProvider:
                                                                             include_content=True)
 
                     new_file_content_str = new_file_content_str.content
-                except Exception as e:                    
+                except Exception as error:
+                    logging.error("Failed to retrieve new file content of %s at version %s. Error: %s", file, version, str(error))
                     new_file_content_str = ""
 
                 edit_type = EDIT_TYPE.MODIFIED
@@ -129,7 +130,8 @@ class AzureDevopsProvider:
                                                                               download=False,
                                                                               include_content=True)
                     original_file_content_str = original_file_content_str.content
-                except Exception as e:
+                except Exception as error:
+                    logging.error("Failed to retrieve original file content of %s at version %s. Error: %s", file, version, str(error))
                     original_file_content_str = ""
 
                 patch = load_large_diff(file, new_file_content_str, original_file_content_str)

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -100,14 +100,17 @@ class AzureDevopsProvider:
                     continue
 
                 version = GitVersionDescriptor(version=head_sha.commit_id, version_type='commit')
-                new_file_content_str = self.azure_devops_client.get_item(repository_id=self.repo_slug,
-                                                                         path=file,
-                                                                         project=self.workspace_slug,
-                                                                         version_descriptor=version,
-                                                                         download=False,
-                                                                         include_content=True)
+                try:
+                    new_file_content_str = self.azure_devops_client.get_item(repository_id=self.repo_slug,
+                                                                            path=file,
+                                                                            project=self.workspace_slug,
+                                                                            version_descriptor=version,
+                                                                            download=False,
+                                                                            include_content=True)
 
-                new_file_content_str = new_file_content_str.content
+                    new_file_content_str = new_file_content_str.content
+                except Exception as e:                    
+                    new_file_content_str = ""
 
                 edit_type = EDIT_TYPE.MODIFIED
                 if diff_types[file] == 'add':
@@ -118,13 +121,16 @@ class AzureDevopsProvider:
                     edit_type = EDIT_TYPE.RENAMED
 
                 version = GitVersionDescriptor(version=base_sha.commit_id, version_type='commit')
-                original_file_content_str = self.azure_devops_client.get_item(repository_id=self.repo_slug,
+                try:
+                    original_file_content_str = self.azure_devops_client.get_item(repository_id=self.repo_slug,
                                                                               path=file,
                                                                               project=self.workspace_slug,
                                                                               version_descriptor=version,
                                                                               download=False,
                                                                               include_content=True)
-                original_file_content_str = original_file_content_str.content
+                    original_file_content_str = original_file_content_str.content
+                except Exception as e:
+                    original_file_content_str = ""
 
                 patch = load_large_diff(file, new_file_content_str, original_file_content_str)
 


### PR DESCRIPTION
There are scenarios when file is not available at specific commit. When this happens, file content should be treated as empty and continue processing next file

Example

`TF401174: The item \'fileA.js\' could not be found in the repository \'X\' at the version specified by \'<Commit: XXXXX >\' (resolved to commit \'XXXXX\')`