### PR TITLE
Fixed help message for bot user

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -241,7 +241,8 @@ class PRReviewer:
         # Add help text if not in CLI mode
         if not get_settings().get("CONFIG.CLI_MODE", False):
             markdown_text += "\n### How to use\n"
-            if user and '[bot]' not in user:
+            bot_user = "[bot]" if get_settings().github_app.override_deployment_type else get_settings().github_app.bot_user
+            if user and bot_user not in user:
                 markdown_text += bot_help_text(user)
             else:
                 markdown_text += actions_help_text


### PR DESCRIPTION
This changes the help message to display properly when running a custom deployment of the PR-Agent app (i.e. not via GitHub Actions, and with the setting `github_app.override_deployment_type=false`)