### PR TITLE
Get previous incremental review

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -78,7 +78,7 @@ class GithubProvider(GitProvider):
         self.previous_review = None
         self.comments = list(self.pr.get_issue_comments())
         for index in range(len(self.comments) - 1, -1, -1):
-            if self.comments[index].body.startswith("## PR Analysis"):
+            if self.comments[index].body.startswith("## PR Analysis") or self.comments[index].body.startswith("## Incremental PR Review"):
                 self.previous_review = self.comments[index]
                 break
 


### PR DESCRIPTION
When getting the last commit in `/review -i` consider also the last __incremental__ review, not just the last __full__ review

Full disclosure I'm not really sure the `/review -i` feature work very well - I might be wrong but it seemed like the actual review in fact addressed all the changes in the PR, and not just the ones from the last review (even though it adds a link to the commit of the last review).   I think the commit list gathered in `/review -i` doesn't propagate to the actual list the reviewer uses. Again, I might be wrong, just took a brief glance at it.