### PR TITLE
Support Custom Domain URLs for Azure DevOps Integration

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -236,9 +236,6 @@ class AzureDevopsProvider:
     def _parse_pr_url(pr_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(pr_url)
 
-        if 'azure.com' not in parsed_url.netloc:
-            raise ValueError("The provided URL is not a valid Azure DevOps URL")
-
         path_parts = parsed_url.path.strip('/').split('/')
 
         if len(path_parts) < 6 or path_parts[4] != 'pullrequest':


### PR DESCRIPTION
This update removes the restriction of having 'azure.com' in the Azure DevOps URL, allowing for custom domain URLs. This enhancement caters to organizations with unique domain setups, ensuring broader usability and flexibility in Azure DevOps integration.