### PR TITLE
Add Blacklist for Non-Editable File Extensions in Documentation

### DIFF
--- a/pr_agent/settings/language_extensions.toml
+++ b/pr_agent/settings/language_extensions.toml
@@ -433,3 +433,6 @@ reStructuredText = [".rst", ".rest", ".rest.txt", ".rst.txt", ]
 wisp = [".wisp", ]
 xBase = [".prg", ".prw", ]
 
+[docs_blacklist_extensions]
+# Disable docs for these extensions of text files and scripts that are not programming languages of function, classes and methods
+docs_blacklist = ['sql', 'txt', 'yaml', 'json', 'xml', 'md', 'rst', 'rest', 'rest.txt', 'rst.txt', 'mdpolicy', 'mdown', 'markdown', 'mdwn', 'mkd', 'mkdn', 'mkdown', 'sh']

--- a/pr_agent/tools/pr_add_docs.py
+++ b/pr_agent/tools/pr_add_docs.py
@@ -65,6 +65,11 @@ class PRAddDocs:
 
     async def _prepare_prediction(self, model: str):
         get_logger().info('Getting PR diff...')
+
+        # Disable adding docs to scripts and other non-relevant text files
+        from pr_agent.algo.language_handler import bad_extensions
+        bad_extensions += get_settings().docs_blacklist_extensions.docs_blacklist
+
         self.patches_diff = get_pr_diff(self.git_provider,
                                         self.token_handler,
                                         model,


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- This PR addresses the issue of adding documentation to non-editable file extensions like SQL, YAML, etc.
- A blacklist of such file extensions has been added to prevent the addition of inline documentation to these files.
- The changes are mainly in the 'pr_agent/tools/pr_add_docs.py' and 'pr_agent/settings/language_extensions.toml' files.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pr_agent/tools/pr_add_docs.py`: Added a check to disable adding docs to scripts and other non-relevant text files. The blacklist of extensions is fetched from the settings.
`pr_agent/settings/language_extensions.toml`: Added a new section 'docs_blacklist_extensions' to list the file extensions for which documentation should not be added.
</details>
