### PR TITLE
Added support for automatic review on push event

### DIFF
--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -142,10 +142,15 @@ class BitbucketProvider(GitProvider):
     def remove_initial_comment(self):
         try:
             for comment in self.temp_comments:
-                self.pr.delete(f"comments/{comment}")
+                self.remove_comment(comment)
         except Exception as e:
             get_logger().exception(f"Failed to remove temp comments, error: {e}")
 
+    def remove_comment(self, comment):
+        try:
+            self.pr.delete(f"comments/{comment}")
+        except Exception as e:
+            get_logger().exception(f"Failed to remove comment, error: {e}")
 
     # funtion to create_inline_comment
     def create_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str):

--- a/pr_agent/git_providers/codecommit_provider.py
+++ b/pr_agent/git_providers/codecommit_provider.py
@@ -221,6 +221,9 @@ class CodeCommitProvider(GitProvider):
     def remove_initial_comment(self):
         return ""  # not implemented yet
 
+    def remove_comment(self, comment):
+        return ""  # not implemented yet
+
     def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str):
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codecommit/client/post_comment_for_compared_commit.html
         raise NotImplementedError("CodeCommit provider does not support publishing inline comments yet")

--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -396,5 +396,8 @@ class GerritProvider(GitProvider):
         # shutil.rmtree(self.repo_path)
         pass
 
+    def remove_comment(self, comment):
+        pass
+
     def get_pr_branch(self):
         return self.repo.head

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -72,6 +72,10 @@ class GitProvider(ABC):
         pass
 
     @abstractmethod
+    def remove_comment(self, comment):
+        pass
+
+    @abstractmethod
     def get_languages(self):
         pass
 

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -63,7 +63,7 @@ class GithubProvider(GitProvider):
 
     def get_commit_range(self):
         last_review_time = self.previous_review.created_at
-        first_new_commit_index = 0
+        first_new_commit_index = None
         for index in range(len(self.commits) - 1, -1, -1):
             if self.commits[index].commit.author.date > last_review_time:
                 self.incremental.first_new_commit_sha = self.commits[index].sha
@@ -71,7 +71,7 @@ class GithubProvider(GitProvider):
             else:
                 self.incremental.last_seen_commit_sha = self.commits[index].sha
                 break
-        return self.commits[first_new_commit_index:]
+        return self.commits[first_new_commit_index:] if first_new_commit_index is not None else []
 
     def get_previous_review(self, *, full: bool, incremental: bool):
         if not (full or incremental):

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -287,9 +287,15 @@ class GitLabProvider(GitProvider):
     def remove_initial_comment(self):
         try:
             for comment in self.temp_comments:
-                comment.delete()
+                self.remove_comment(comment)
         except Exception as e:
             get_logger().exception(f"Failed to remove temp comments, error: {e}")
+
+    def remove_comment(self, comment):
+        try:
+            comment.delete()
+        except Exception as e:
+            get_logger().exception(f"Failed to remove comment, error: {e}")
 
     def get_title(self):
         return self.mr.title

--- a/pr_agent/git_providers/local_git_provider.py
+++ b/pr_agent/git_providers/local_git_provider.py
@@ -140,6 +140,9 @@ class LocalGitProvider(GitProvider):
     def remove_initial_comment(self):
         pass  # Not applicable to the local git provider, but required by the interface
 
+    def remove_comment(self, comment):
+        pass  # Not applicable to the local git provider, but required by the interface
+
     def get_languages(self):
         """
         Calculate percentage of languages in repository. Used for hunk prioritisation.

--- a/pr_agent/servers/utils.py
+++ b/pr_agent/servers/utils.py
@@ -1,5 +1,8 @@
 import hashlib
 import hmac
+import time
+from collections import defaultdict
+from typing import Callable, Any
 
 from fastapi import HTTPException
 
@@ -25,3 +28,59 @@ def verify_signature(payload_body, secret_token, signature_header):
 class RateLimitExceeded(Exception):
     """Raised when the git provider API rate limit has been exceeded."""
     pass
+
+
+class DefaultDictWithTimeout(defaultdict):
+    """A defaultdict with a time-to-live (TTL)."""
+
+    def __init__(
+        self,
+        default_factory: Callable[[], Any] = None,
+        ttl: int = None,
+        refresh_interval: int = 60,
+        update_key_time_on_get: bool = True,
+        *args,
+        **kwargs,
+    ):
+        """
+        Args:
+            default_factory: The default factory to use for keys that are not in the dictionary.
+            ttl: The time-to-live (TTL) in seconds.
+            refresh_interval: How often to refresh the dict and delete items older than the TTL.
+            update_key_time_on_get: Whether to update the access time of a key also on get (or only when set).
+        """
+        super().__init__(default_factory, *args, **kwargs)
+        self.__key_times = dict()
+        self.__ttl = ttl
+        self.__refresh_interval = refresh_interval
+        self.__update_key_time_on_get = update_key_time_on_get
+        self.__last_refresh = self.__time() - self.__refresh_interval
+
+    @staticmethod
+    def __time():
+        return time.monotonic()
+
+    def __refresh(self):
+        if self.__ttl is None:
+            return
+        request_time = self.__time()
+        if request_time - self.__last_refresh > self.__refresh_interval:
+            return
+        to_delete = [key for key, key_time in self.__key_times.items() if request_time - key_time > self.__ttl]
+        for key in to_delete:
+            del self[key]
+        self.__last_refresh = request_time
+
+    def __getitem__(self, __key):
+        if self.__update_key_time_on_get:
+            self.__key_times[__key] = self.__time()
+        self.__refresh()
+        return super().__getitem__(__key)
+
+    def __setitem__(self, __key, __value):
+        self.__key_times[__key] = self.__time()
+        return super().__setitem__(__key, __value)
+
+    def __delitem__(self, __key):
+        del self.__key_times[__key]
+        return super().__delitem__(__key)

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -84,13 +84,13 @@ pr_commands = [
     "/describe --pr_description.add_original_user_description=true --pr_description.keep_original_user_title=true",
     "/auto_review",
 ]
-# settings for "push" event
-handle_push_event = false
-push_event_ignore_bot_commits = true
-push_event_ignore_merge_commits = true
-push_event_wait_for_initial_review = true
-push_event_pending_triggers_backlog = true
-push_event_pending_triggers_ttl = 300
+# settings for "pull_request" event with "synchronize" action - used to detect and handle push triggers for new commits
+handle_push_trigger = false
+push_trigger_ignore_bot_commits = true
+push_trigger_ignore_merge_commits = true
+push_trigger_wait_for_initial_review = true
+push_trigger_pending_tasks_backlog = true
+push_trigger_pending_tasks_ttl = 300
 push_commands = [
     "/describe --pr_description.add_original_user_description=true --pr_description.keep_original_user_title=true",
     """/auto_review -i \

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -83,6 +83,26 @@ pr_commands = [
     "/describe --pr_description.add_original_user_description=true --pr_description.keep_original_user_title=true",
     "/auto_review",
 ]
+# settings for "push" event
+handle_push_event = false
+push_event_ignore_bot_commits = true
+push_event_ignore_merge_commits = true
+push_event_wait_for_initial_review = true
+push_event_pending_triggers_backlog = true
+push_event_pending_triggers_ttl = 300
+push_commands = [
+    "/describe --pr_description.add_original_user_description=true --pr_description.keep_original_user_title=true",
+    """/auto_review -i \
+       --pr_reviewer.require_focused_review=false \
+       --pr_reviewer.require_score_review=false \
+       --pr_reviewer.require_tests_review=false \
+       --pr_reviewer.require_security_review=false \
+       --pr_reviewer.require_estimate_effort_to_review=false \
+       --pr_reviewer.num_code_suggestions=0 \
+       --pr_reviewer.inline_code_comments=false \
+       --pr_reviewer.extra_instructions='' \
+    """
+]
 
 [gitlab]
 # URL to the gitlab service

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -24,6 +24,7 @@ num_code_suggestions=4
 inline_code_comments = false
 ask_and_reflect=false
 automatic_review=true
+remove_previous_review_comment=false
 extra_instructions = ""
 
 [pr_description] # /describe #
@@ -100,6 +101,7 @@ push_commands = [
        --pr_reviewer.require_estimate_effort_to_review=false \
        --pr_reviewer.num_code_suggestions=0 \
        --pr_reviewer.inline_code_comments=false \
+       --pr_reviewer.remove_previous_review_comment=true \
        --pr_reviewer.extra_instructions='' \
     """
 ]

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -335,7 +335,7 @@ class PRReviewer:
 
     def _remove_previous_review_comment(self, comment):
         """
-        Get the previous review comment if it exists.
+        Remove the previous review comment if it exists.
         """
         try:
             if get_settings().pr_reviewer.remove_previous_review_comment and comment:

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -114,9 +114,10 @@ class PRReviewer:
 
             if get_settings().config.publish_output:
                 get_logger().info('Pushing PR review...')
+                previous_review_comment = self._get_previous_review_comment()
                 self.git_provider.publish_comment(pr_comment)
                 self.git_provider.remove_initial_comment()
-
+                self._remove_previous_review_comment(previous_review_comment)
                 if get_settings().pr_reviewer.inline_code_comments:
                     get_logger().info('Pushing inline code comments...')
                     self._publish_inline_code_comments()
@@ -318,3 +319,26 @@ class PRReviewer:
                     break
 
         return question_str, answer_str
+
+    def _get_previous_review_comment(self):
+        """
+        Get the previous review comment if it exists.
+        """
+        try:
+            if get_settings().pr_reviewer.remove_previous_review_comment and hasattr(self.git_provider, "get_previous_review"):
+                return self.git_provider.get_previous_review(
+                    full=not self.incremental.is_incremental,
+                    incremental=self.incremental.is_incremental,
+                )
+        except Exception as e:
+            get_logger().exception(f"Failed to get previous review comment, error: {e}")
+
+    def _remove_previous_review_comment(self, comment):
+        """
+        Get the previous review comment if it exists.
+        """
+        try:
+            if get_settings().pr_reviewer.remove_previous_review_comment and comment:
+                self.git_provider.remove_comment(comment)
+        except Exception as e:
+            get_logger().exception(f"Failed to remove previous review comment, error: {e}")


### PR DESCRIPTION
The new feature can be enabled via the new configuration `github_app.handle_push_trigger`. To avoid any unwanted side-effects, the current default of this configuration is set to `false`.

The high level flow (assuming the configuration is enabled):
1. new code is pushed to the repo
2. receive pull_request.synchronize event from GitHub
3. extract PR url from request body
4. validate trigger is valid to run the agent (PR is open, no duplicate triggers, etc.)
5. perform configured commands (e.g. `/describe`, `/review -i`)

The push trigger flow is guarded by a backlog queue so that multiple events for the same PR won't trigger multiple duplicate runs of the PR-Agent commands. Example timeline:
1. push 1 - start handling event
2. push 2 - waiting to be handled while push 1 event is still running
3. push 3 - event is dropped since handling it and handling push 2 is the same, so it is redundant
6. push 1 finished being handled
7. push 2 awakens from wait and continues handling (potentially reviewing the commits of both push 2 and push 3)

All of these options are configurable and can be enabled/disabled as per the user's desire.

Additional minor changes in this PR:
1. Created `DefaultDictWithTimeout` utility class to avoid too much boilerplate code in managing caches for outdated triggers.
2. Guard against running incremental review when there are no new commits.
3. Added option for the `/review` and `/review -i` commands to delete their previous comment.
4. Minor styling changes for incremental review text.