### PR TITLE
remove workslug from common file

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -335,9 +335,8 @@ class GithubProvider(GitProvider):
             issue_number = int(path_parts[3])
         except ValueError as e:
             raise ValueError("Unable to convert issue number to integer") from e
-        workspace_slug = None
-
-        return workspace_slug, repo_name, issue_number
+        
+        return repo_name, issue_number
 
     def _get_github_client(self):
         deployment_type = get_settings().get("GITHUB.DEPLOYMENT_TYPE", "user")
@@ -458,13 +457,15 @@ class GithubProvider(GitProvider):
     def get_repo_issues(self, repo_obj):
         return list(repo_obj.get_issues(state='all'))
     
-    def get_issues_comments(self, workspace_slug, repo_name, original_issue_number):
+    def get_issues_comments(self, issue):
+        repo_name, original_issue_number = self._parse_issue_url(issue)
         return self.repo_obj.get_issue(original_issue_number)
     
     def get_issue_url(self, issue):
         return issue.html_url
     
-    def create_issue_comment(self, similar_issues_str, workspace_slug, repo_name, original_issue_number):
+    def create_issue_comment(self, similar_issues_str, issue_url, original_issue_number):
+        repo_name, original_issue_number = self._parse_issue_url(issue_url)
         try:
             issue = self.repo_obj.get_issue(original_issue_number)
             issue.create_comment(similar_issues_str)
@@ -477,14 +478,15 @@ class GithubProvider(GitProvider):
     def get_issue_number(self, issue):
         return issue.number
     
-    def get_issues_comments(self, workspace_slug, repo_name, original_issue_number):
+    def get_issues_comments(self, issue):
+        repo_name, original_issue_number = self._parse_issue_url(issue)
         issue = self.repo_obj.get_issue(original_issue_number)
         return list(issue.get_comments())
     
     def get_issue_body(self, issue):
         return issue.body
     
-    def get_username(self, issue, workspace_slug):
+    def get_username(self, issue, issue_url):
         return issue.user.login
     
     def get_issue_created_at(self, issue):
@@ -493,10 +495,13 @@ class GithubProvider(GitProvider):
     def get_issue_comment_body(self, comment):
         return comment.body
     
-    def get_issue(self, workspace_slug, repo_name, original_issue_number):
-        return self.repo_obj.get_issue(int(original_issue_number))
+    def get_issue(self, issue_url):
+        repo_name, original_issue_number = self._parse_issue_url(issue_url)
+        issue = self.repo_obj.get_issue(original_issue_number)
+        return issue, original_issue_number
     
-    def get_repo_obj(self, workspace_slug, repo_name):
+    def get_repo_obj_parse_issue_url(self, issue_url):
+        repo_name, original_issue_number = self._parse_issue_url(issue_url)
         return self.github_client.get_repo(repo_name)
     
     def get_repo_name_for_indexing(self, repo_obj):
@@ -507,9 +512,15 @@ class GithubProvider(GitProvider):
             return True
         return False
     
-    def get_issue_numbers(self, issues_list):
-        return str([issue.number for issue in issues_list])
-    
     def get_issue_numbers_from_list(self, r):
         return int(r.split('.')[0].split('_')[-1])
+    
+    def get_similar_issues(self, issue_url, issue_number_similar):
+        repo_name, original_issue_number = self._parse_issue_url(issue_url)        issue = self.github_client.get_repo(repo_name).get_issue(issue_number_similar)
+        return issue
+
+    def get_main_issue(self, issue_url):
+        repo_name, original_issue_number = self._parse_issue_url(issue_url)
+        issue = self.github_client.get_repo(repo_name).get_issue(original_issue_number)
+        return issue
 


### PR DESCRIPTION
Similar Issue in Bitbucket:

In this pull request (PR), I have created a common file to address a similar issue. The functions within this common file are utilized for both GitHub and Bitbucket. Prior to this, these functions were only compatible with GitHub. I've created functions with the same name for both GitHub and Bitbucket. Consequently, when the 'similar_issue' command is executed, it checks the Git provider and subsequently performs all processes based on the specific Git provider in use.