### PR TITLE
Refactor Command Handling for Different Triggers

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -122,7 +122,7 @@ async def handle_request(body: Dict[str, Any], event: str):
                 if body.get("requested_reviewer", {}).get("login", "") != bot_user:
                     return {}
             get_logger().info(f"Performing review for {api_url=} because of {event=} and {action=}")
-            await _perform_commands(agent, body, api_url, log_context)
+            await _perform_commands("pr_commands", agent, body, api_url, log_context)
 
     # handle pull_request event with synchronize action - "push trigger" for new commits
     elif event == 'pull_request' and action == 'synchronize' and get_settings().github_app.handle_push_trigger:
@@ -174,7 +174,7 @@ async def handle_request(body: Dict[str, Any], event: str):
                 get_logger().info(f"Skipping incremental review because there was no initial review for {api_url=} yet")
                 return {}
             get_logger().info(f"Performing incremental review for {api_url=} because of {event=} and {action=}")
-            await _perform_commands(agent, body, api_url, log_context)
+            await _perform_commands("push_commands", agent, body, api_url, log_context)
 
         finally:
             # release the waiting task block
@@ -203,9 +203,9 @@ def _check_pull_request_event(action: str, body: dict, log_context: dict, bot_us
     return pull_request, api_url
 
 
-async def _perform_commands(agent: PRAgent, body: dict, api_url: str, log_context: dict):
+async def _perform_commands(commands_conf: str, agent: PRAgent, body: dict, api_url: str, log_context: dict):
     apply_repo_settings(api_url)
-    commands = get_settings().github_app.pr_commands
+    commands = get_settings().get(f"github_app.{commands_conf}")
     for command in commands:
         split_command = command.split(" ")
         command = split_command[0]


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR refactors the command handling in the GitHub app server. The changes allow different command configurations to be used depending on the trigger event. Specifically:
- The `_perform_commands` function now takes an additional parameter `commands_conf` to specify the command configuration to use.
- For 'review_requested' events, the 'pr_commands' configuration is used.
- For 'synchronize' events, the 'push_commands' configuration is used.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pr_agent/servers/github_app.py`: The `_perform_commands` function has been modified to take an additional parameter `commands_conf`, which is used to determine the command configuration to use. This parameter is passed in from the `handle_request` function, which uses 'pr_commands' for 'review_requested' events and 'push_commands' for 'synchronize' events.
</details>
