### PR TITLE
Fix formatting when last commit message contains _

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -239,7 +239,7 @@ class PRReviewer:
             last_commit_msg = self.incremental.commits_range[0].commit.message if self.incremental.commits_range else ""
             incremental_review_markdown_text = f"Starting from commit {last_commit_url}"
             if last_commit_msg:
-                incremental_review_markdown_text += f"  \n_({last_commit_msg.splitlines(keepends=False)[0]})_"
+                incremental_review_markdown_text += f"  \n_({last_commit_msg.splitlines(keepends=False)[0].replace('_', r'\_')})_"
             data = OrderedDict(data)
             data.update({'Incremental PR Review': {
                 "⏮️ Review for commits since previous PR-Agent review": incremental_review_markdown_text}})


### PR DESCRIPTION
If the last commit message is this:  
Fix in _some_func

Then before this fix it would appear this way in the incremental PR review:  
_(Fix in _some_func)_

But after this fix it would appear correctly this way:  
_(Fix in \_some\_func)_