### PR TITLE
Fix Syntax Error in f-string Expression

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -239,7 +239,7 @@ class PRReviewer:
             last_commit_msg = self.incremental.commits_range[0].commit.message if self.incremental.commits_range else ""
             incremental_review_markdown_text = f"Starting from commit {last_commit_url}"
             if last_commit_msg:
-                incremental_review_markdown_text += f"  \n_({last_commit_msg.splitlines(keepends=False)[0].replace('_', r'\_')})_"
+                incremental_review_markdown_text += f"  \n_({last_commit_msg.splitlines(keepends=False)[0].replace('__', '__')})_"
             data = OrderedDict(data)
             data.update({'Incremental PR Review': {
                 "⏮️ Review for commits since previous PR-Agent review": incremental_review_markdown_text}})

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -239,7 +239,8 @@ class PRReviewer:
             last_commit_msg = self.incremental.commits_range[0].commit.message if self.incremental.commits_range else ""
             incremental_review_markdown_text = f"Starting from commit {last_commit_url}"
             if last_commit_msg:
-                incremental_review_markdown_text += f"  \n_({last_commit_msg.splitlines(keepends=False)[0].replace('__', '__')})_"
+                replacement = last_commit_msg.splitlines(keepends=False)[0].replace('_', r'\_')
+                incremental_review_markdown_text += f"  \n_({replacement})_"
             data = OrderedDict(data)
             data.update({'Incremental PR Review': {
                 "⏮️ Review for commits since previous PR-Agent review": incremental_review_markdown_text}})


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR fixes a syntax error in an f-string expression in the `pr_reviewer.py` file. The error was caused by the inclusion of a backslash in the expression part of the f-string. The fix involves replacing the backslash with a suitable replacement.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pr_agent/tools/pr_reviewer.py`: The f-string expression that was causing a SyntaxError has been fixed. The backslash in the expression part of the f-string has been replaced with a suitable replacement. The modified f-string is used to append a commit message to the `incremental_review_markdown_text` string.
</details>
