### PR TITLE
Fix error in `get_main_pr_languages` when the diff is empty

### DIFF
--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -143,6 +143,9 @@ def get_main_pr_language(languages, files) -> str:
     if not languages:
         get_logger().info("No languages detected")
         return main_language_str
+    if not files:
+        get_logger().info("No files in diff")
+        return main_language_str
 
     try:
         top_language = max(languages, key=languages.get).lower()


### PR DESCRIPTION
This can happen for example when you have one commit add a line to a file and the next commit deletes that line. Then if those are the only 2 commits in the PR the diff will be empty.