### PR TITLE
Adding Middleware to FastAPI Initialization

### DIFF
--- a/pr_agent/servers/serverless.py
+++ b/pr_agent/servers/serverless.py
@@ -1,12 +1,15 @@
 from fastapi import FastAPI
 from mangum import Mangum
+from starlette.middleware import Middleware
+from starlette_context.middleware import RawContextMiddleware
 
 from pr_agent.log import setup_logger
 from pr_agent.servers.github_app import router
 
 setup_logger()
 
-app = FastAPI()
+middleware = [Middleware(RawContextMiddleware)]
+app = FastAPI(middleware=middleware)
 app.include_router(router)
 
 handler = Mangum(app, lifespan="off")


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses a bug where middleware was not being added during the initialization of FastAPI in a lambda function. The following changes have been made:
- Middleware has been imported from starlette.
- Middleware has been added to the FastAPI app during initialization.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pr_agent/servers/serverless.py`: Middleware has been imported from starlette and added to the FastAPI app during its initialization. This change ensures that the middleware is correctly set up when the FastAPI app is created.
</details>

___
## User Description

In a function for a Lambda function, middleware was not added during the initialization of FastAPI, and it was causing a [ContextDoesNotExistError](https://starlette-context.readthedocs.io/en/latest/errors.html), so I added the middleware.