### PR TITLE
Refactoring PR Labels Handling and Display

### DIFF
--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -34,6 +34,7 @@ add_original_user_description=false
 keep_original_user_title=false
 use_bullet_points=true
 extra_instructions = ""
+enable_pr_type=true
 
 # markers
 use_description_markers=false

--- a/pr_agent/settings/pr_custom_labels.toml
+++ b/pr_agent/settings/pr_custom_labels.toml
@@ -39,7 +39,6 @@ PR Type:
 {{ custom_labels_examples }}
 {%- else %}
   - Bug fix
-  - Tests
 {%- endif %}
 ```
 

--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -18,22 +18,22 @@ PR Title:
   type: string
   description: an informative title for the PR, describing its main theme
 PR Type:
-  type: array
+  type: string
+  enum:
+    - Bug fix
+    - Tests
+    - Refactoring
+    - Enhancement
+    - Documentation
+    - Other
 {%- if enable_custom_labels %}
-  description: One or more labels that describe the PR type. Don't output the description in the parentheses.
-{%- endif %}
+PR Labels:
+  type: array
+  description: One or more labels that describe the PR labels. Don't output the description in the parentheses.
   items:
     type: string
     enum:
-{%- if enable_custom_labels %}
 {{ custom_labels }}
-{%- else %}
-      - Bug fix
-      - Tests
-      - Refactoring
-      - Enhancement
-      - Documentation
-      - Other
 {%- endif %}
 PR Description:
   type: string
@@ -58,10 +58,10 @@ Example output:
 PR Title: |-
   ...
 PR Type:
+  ...
 {%- if enable_custom_labels %}
+PR Labels:
 {{ custom_labels_examples }}
-{%- else %}
-  - Bug fix
 {%- endif %}
 PR Description: |-
   ...

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -51,22 +51,13 @@ PR Analysis:
     description: summary of the PR in 2-3 sentences.
   Type of PR:
     type: string
-{%- if enable_custom_labels %}
-  description: One or more labels that describe the PR type. Don't output the description in the parentheses.
-{%- endif %}
-  items:
-    type: string
     enum:
-{%- if enable_custom_labels %}
-{{ custom_labels }}
-{%- else %}
       - Bug fix
       - Tests
       - Refactoring
       - Enhancement
       - Documentation
       - Other
-{%- endif %}
 {%- if require_score %}
   Score:
     type: int

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -230,6 +230,8 @@ class PRDescription:
         # Don't display 'PR Labels'
         if 'PR Labels' in self.data:
             self.data.pop('PR Labels')
+        if not get_settings().pr_description.enable_pr_type:
+            self.data.pop('PR Type')
         for key, value in self.data.items():
             markdown_text += f"## {key}\n\n"
             markdown_text += f"{value}\n\n"

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -172,11 +172,11 @@ class PRDescription:
         pr_types = []
 
         # If the 'PR Type' key is present in the dictionary, split its value by comma and assign it to 'pr_types'
-        if 'PR Type' in self.data:
-            if type(self.data['PR Type']) == list:
-                pr_types = self.data['PR Type']
-            elif type(self.data['PR Type']) == str:
-                pr_types = self.data['PR Type'].split(',')
+        if 'PR Labels' in self.data:
+            if type(self.data['PR Labels']) == list:
+                pr_types = self.data['PR Labels']
+            elif type(self.data['PR Labels']) == str:
+                pr_types = self.data['PR Labels'].split(',')
 
         return pr_types
 

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -177,7 +177,11 @@ class PRDescription:
                 pr_types = self.data['PR Labels']
             elif type(self.data['PR Labels']) == str:
                 pr_types = self.data['PR Labels'].split(',')
-
+        elif 'PR Type' in self.data:
+            if type(self.data['PR Type']) == list:
+                pr_types = self.data['PR Type']
+            elif type(self.data['PR Type']) == str:
+                pr_types = self.data['PR Type'].split(',')
         return pr_types
 
     def _prepare_pr_answer_with_markers(self) -> Tuple[str, str]:
@@ -223,6 +227,9 @@ class PRDescription:
 
         # Iterate over the dictionary items and append the key and value to 'markdown_text' in a markdown format
         markdown_text = ""
+        # Don't display 'PR Labels'
+        if 'PR Labels' in self.data:
+            self.data.pop('PR Labels')
         for key, value in self.data.items():
             markdown_text += f"## {key}\n\n"
             markdown_text += f"{value}\n\n"

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -156,7 +156,7 @@ class PRReviewer:
         variables["diff"] = self.patches_diff  # update diff
 
         environment = Environment(undefined=StrictUndefined)
-        set_custom_labels(variables)
+        # set_custom_labels(variables)
         system_prompt = environment.from_string(get_settings().pr_review_prompt.system).render(variables)
         user_prompt = environment.from_string(get_settings().pr_review_prompt.user).render(variables)
 


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR introduces several changes related to PR labels handling and display:
- The 'PR Labels' key is now used instead of 'PR Type' to prepare labels.
- The 'PR Labels' key is not displayed in the markdown text.
- A new configuration option 'enable_pr_type' is added to control whether to display 'PR Type' in the markdown text.
- The 'set_custom_labels' function call is commented out in 'pr_reviewer.py'.
- The 'Tests' option is removed from 'PR Type' in 'pr_custom_labels.toml'.
- The 'PR Type' is changed from array to string in 'pr_description_prompts.toml'.
- The 'PR Labels' key is added to 'pr_description_prompts.toml'.
- The 'PR Type' is changed from array to string and the 'PR Labels' key is removed in 'pr_reviewer_prompts.toml'.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pr_agent/tools/pr_description.py`: The 'PR Labels' key is now used instead of 'PR Type' to prepare labels. The 'PR Labels' key is not displayed in the markdown text. A new configuration option 'enable_pr_type' is added to control whether to display 'PR Type' in the markdown text.
`pr_agent/tools/pr_reviewer.py`: The 'set_custom_labels' function call is commented out.
`pr_agent/settings/configuration.toml`: A new configuration option 'enable_pr_type' is added.
`pr_agent/settings/pr_custom_labels.toml`: The 'Tests' option is removed from 'PR Type'.
`pr_agent/settings/pr_description_prompts.toml`: The 'PR Type' is changed from array to string and the 'PR Labels' key is added.
`pr_agent/settings/pr_reviewer_prompts.toml`: The 'PR Type' is changed from array to string and the 'PR Labels' key is removed.
</details>
