### PR TITLE
Removal of Redundant Logger Setup

### DIFF
--- a/pr_agent/servers/serverless.py
+++ b/pr_agent/servers/serverless.py
@@ -3,10 +3,8 @@ from mangum import Mangum
 from starlette.middleware import Middleware
 from starlette_context.middleware import RawContextMiddleware
 
-from pr_agent.log import setup_logger
 from pr_agent.servers.github_app import router
 
-setup_logger()
 
 middleware = [Middleware(RawContextMiddleware)]
 app = FastAPI(middleware=middleware)


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR removes the unnecessary call to `setup_logger()` in the `serverless.py` file. The logger setup is already being handled within `github_app.py`, making the additional call in `serverless.py` redundant.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `pr_agent/servers/serverless.py`: Removed the import and call to `setup_logger()`.
</details>
