### PR TITLE
Add Persistent Review Feature to PR Agent

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## Unreleased
+- review tool now posts persistent comments by default
+
 ## [Version 0.9] - 2023-10-29
 - codiumai/pr-agent:0.9
 - codiumai/pr-agent:0.9-github_app

--- a/Usage.md
+++ b/Usage.md
@@ -173,7 +173,7 @@ push_commands = [
     "/auto_review -i --pr_reviewer.remove_previous_review_comment=true",
 ]
 ```
-The means that when new code is pused to the PR, the PR-Agent will run the `describe` and incremental `auto_review` tools.  
+The means that when new code is pushed to the PR, the PR-Agent will run the `describe` and incremental `auto_review` tools.  
 For the describe tool, the `add_original_user_description` and `keep_original_user_title` parameters will be set to true.  
 For the `auto_review` tool, it will run in incremental mode, and the `remove_previous_review_comment` parameter will be set to true.
 

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -24,6 +24,8 @@ Under the section 'pr_reviewer', the [configuration file](./../pr_agent/settings
 - `num_code_suggestions`: number of code suggestions provided by the 'review' tool. Default is 4.
 - `inline_code_comments`: if set to true, the tool will publish the code suggestions as comments on the code diff. Default is false.
 - `automatic_review`: if set to false, no automatic reviews will be done. Default is true.
+- `remove_previous_review_comment`: if set to true, the tool will remove the previous review comment before adding a new one. Default is false.
+- `persistent_comment`: if set to true, the review comment will be persistent. Default is true.
 - `extra_instructions`: Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".
 - To enable `custom labels`, apply the configuration changes described [here](./GENERATE_CUSTOM_LABELS.md#configuration-changes) 
 ####  Incremental Mode

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -154,12 +154,17 @@ class BitbucketProvider(GitProvider):
         return diff_files
 
 
-    def publish_persistent_review(self, pr_comment: str):
+    def publish_persistent_comment(self, pr_comment: str,
+                                   initial_text="## PR Analysis",
+                                   updated_text="## PR Analysis (updated)"):
         try:
             for comment in self.pr.comments():
                 body = comment.raw
-                if '## PR Analysis' in body:
-                    pr_comment_updated = pr_comment.replace('## PR Analysis\n', '## PR Analysis (updated)\n')
+                if initial_text in body:
+                    if updated_text:
+                        pr_comment_updated = pr_comment.replace(initial_text, updated_text)
+                    else:
+                        pr_comment_updated = pr_comment
                     d = {"content": {"raw": pr_comment_updated}}
                     response = comment._update_data(comment.put(None, data=d))
                     return

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -155,18 +155,17 @@ class BitbucketProvider(GitProvider):
 
 
     def publish_persistent_review(self, pr_comment: str):
-        ## not working yet, need to find a way to update the comment
-        # try:
-        #     for comment in self.pr.comments():
-        #         body = comment.raw
-        #         if '## PR Analysis' in body:
-        #             pr_comment_updated = pr_comment.replace('## PR Analysis\n', '## PR Analysis (updated)\n')
-        #             comment.data['content']['raw']= pr_comment_updated
-        #             comment.update()
-        #             return
-        # except Exception as e:
-        #     get_logger().exception(f"Failed to update persistent review, error: {e}")
-        #     pass
+        try:
+            for comment in self.pr.comments():
+                body = comment.raw
+                if '## PR Analysis' in body:
+                    pr_comment_updated = pr_comment.replace('## PR Analysis\n', '## PR Analysis (updated)\n')
+                    d = {"content": {"raw": pr_comment_updated}}
+                    response = comment._update_data(comment.put(None, data=d))
+                    return
+        except Exception as e:
+            get_logger().exception(f"Failed to update persistent review, error: {e}")
+            pass
         self.publish_comment(pr_comment)
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -153,10 +153,7 @@ class BitbucketProvider(GitProvider):
         self.diff_files = diff_files
         return diff_files
 
-
-    def publish_persistent_comment(self, pr_comment: str,
-                                   initial_text="## PR Analysis",
-                                   updated_text="## PR Analysis (updated)"):
+    def publish_persistent_comment(self, pr_comment: str, initial_text: str, updated_text: str):
         try:
             for comment in self.pr.comments():
                 body = comment.raw

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -153,6 +153,22 @@ class BitbucketProvider(GitProvider):
         self.diff_files = diff_files
         return diff_files
 
+
+    def publish_persistent_review(self, pr_comment: str):
+        ## not working yet, need to find a way to update the comment
+        # try:
+        #     for comment in self.pr.comments():
+        #         body = comment.raw
+        #         if '## PR Analysis' in body:
+        #             pr_comment_updated = pr_comment.replace('## PR Analysis\n', '## PR Analysis (updated)\n')
+        #             comment.data['content']['raw']= pr_comment_updated
+        #             comment.update()
+        #             return
+        # except Exception as e:
+        #     get_logger().exception(f"Failed to update persistent review, error: {e}")
+        #     pass
+        self.publish_comment(pr_comment)
+
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         comment = self.pr.comment(pr_comment)
         if is_temporary:

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -44,7 +44,7 @@ class GitProvider(ABC):
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         pass
 
-    def publish_persistent_review(self, pr_comment: str):
+    def publish_persistent_comment(self, pr_comment: str):
         self.publish_comment(pr_comment)
 
     @abstractmethod

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -44,7 +44,7 @@ class GitProvider(ABC):
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         pass
 
-    def publish_persistent_comment(self, pr_comment: str):
+    def publish_persistent_comment(self, pr_comment: str, initial_text: str, updated_text: str):
         self.publish_comment(pr_comment)
 
     @abstractmethod

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -44,6 +44,9 @@ class GitProvider(ABC):
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         pass
 
+    def publish_persistent_review(self, pr_comment: str):
+        self.publish_comment(pr_comment)
+
     @abstractmethod
     def publish_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str):
         pass

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -154,11 +154,17 @@ class GithubProvider(GitProvider):
     def publish_description(self, pr_title: str, pr_body: str):
         self.pr.edit(title=pr_title, body=pr_body)
 
-    def publish_persistent_review(self, pr_comment: str):
+    def publish_persistent_comment(self, pr_comment: str,
+                                   initial_text="## PR Analysis",
+                                   updated_text="## PR Analysis (updated)"):
         prev_comments = list(self.pr.get_issue_comments())
         for comment in prev_comments:
-            if comment.body.startswith('## PR Analysis'):
-                pr_comment_updated = pr_comment.replace('## PR Analysis\n', '## PR Analysis (updated)\n')
+            body = comment.body
+            if body.startswith(initial_text):
+                if updated_text:
+                    pr_comment_updated = pr_comment.replace(initial_text, updated_text)
+                else:
+                    pr_comment_updated = pr_comment
                 response = comment.edit(pr_comment_updated)
                 return
         self.publish_comment(pr_comment)

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -154,9 +154,7 @@ class GithubProvider(GitProvider):
     def publish_description(self, pr_title: str, pr_body: str):
         self.pr.edit(title=pr_title, body=pr_body)
 
-    def publish_persistent_comment(self, pr_comment: str,
-                                   initial_text="## PR Analysis",
-                                   updated_text="## PR Analysis (updated)"):
+    def publish_persistent_comment(self, pr_comment: str, initial_text: str, updated_text: str):
         prev_comments = list(self.pr.get_issue_comments())
         for comment in prev_comments:
             body = comment.body

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -154,10 +154,20 @@ class GithubProvider(GitProvider):
     def publish_description(self, pr_title: str, pr_body: str):
         self.pr.edit(title=pr_title, body=pr_body)
 
+    def publish_persistent_review(self, pr_comment: str):
+        prev_comments = list(self.pr.get_issue_comments())
+        for comment in prev_comments:
+            if comment.body.startswith('## PR Analysis'):
+                pr_comment_updated = pr_comment.replace('## PR Analysis\n', '## PR Analysis (updated)\n')
+                response = comment.edit(pr_comment_updated)
+                return
+        self.publish_comment(pr_comment)
+
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
         if is_temporary and not get_settings().config.publish_output_progress:
             get_logger().debug(f"Skipping publish_comment for temporary comment: {pr_comment}")
             return
+
         response = self.pr.create_issue_comment(pr_comment)
         if hasattr(response, "user") and hasattr(response.user, "login"):
             self.github_user_id = response.user.login

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -136,11 +136,16 @@ class GitLabProvider(GitProvider):
         except Exception as e:
             get_logger().exception(f"Could not update merge request {self.id_mr} description: {e}")
 
-    def publish_persistent_review(self, pr_comment: str):
+    def publish_persistent_comment(self, pr_comment: str,
+                                   initial_text="## PR Analysis",
+                                   updated_text="## PR Analysis (updated)"):
         try:
             for comment in self.mr.notes.list(get_all=True)[::-1]:
-                if comment.body.startswith('## PR Analysis'):
-                    pr_comment_updated = pr_comment.replace('## PR Analysis\n', '## PR Analysis (updated)\n')
+                if comment.body.startswith(initial_text):
+                    if updated_text:
+                        pr_comment_updated = pr_comment.replace(initial_text, updated_text)
+                    else:
+                        pr_comment_updated = pr_comment
                     response = self.mr.notes.update(comment.id, {'body': pr_comment_updated})
                     return
         except Exception as e:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -136,9 +136,7 @@ class GitLabProvider(GitProvider):
         except Exception as e:
             get_logger().exception(f"Could not update merge request {self.id_mr} description: {e}")
 
-    def publish_persistent_comment(self, pr_comment: str,
-                                   initial_text="## PR Analysis",
-                                   updated_text="## PR Analysis (updated)"):
+    def publish_persistent_comment(self, pr_comment: str, initial_text: str, updated_text: str):
         try:
             for comment in self.mr.notes.list(get_all=True)[::-1]:
                 if comment.body.startswith(initial_text):

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -136,6 +136,18 @@ class GitLabProvider(GitProvider):
         except Exception as e:
             get_logger().exception(f"Could not update merge request {self.id_mr} description: {e}")
 
+    def publish_persistent_review(self, pr_comment: str):
+        try:
+            for comment in self.mr.notes.list(get_all=True)[::-1]:
+                if comment.body.startswith('## PR Analysis'):
+                    pr_comment_updated = pr_comment.replace('## PR Analysis\n', '## PR Analysis (updated)\n')
+                    response = self.mr.notes.update(comment.id, {'body': pr_comment_updated})
+                    return
+        except Exception as e:
+            get_logger().exception(f"Failed to update persistent review, error: {e}")
+            pass
+        self.publish_comment(pr_comment)
+
     def publish_comment(self, mr_comment: str, is_temporary: bool = False):
         comment = self.mr.notes.create({'body': mr_comment})
         if is_temporary:

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -26,6 +26,7 @@ inline_code_comments = false
 ask_and_reflect=false
 automatic_review=true
 remove_previous_review_comment=false
+persistent_comment=true
 extra_instructions = ""
 # specific configurations for incremental review (/review -i)
 require_all_thresholds_for_incremental_review=false

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -120,7 +120,9 @@ class PRReviewer:
 
                 # publish the review
                 if get_settings().pr_reviewer.persistent_comment and not self.incremental.is_incremental:
-                    self.git_provider.publish_persistent_comment(pr_comment)
+                    self.git_provider.publish_persistent_comment(pr_comment,
+                                                                 initial_text="## PR Analysis",
+                                                                 updated_text="## PR Analysis (updated)")
                 else:
                     self.git_provider.publish_comment(pr_comment)
 

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -120,7 +120,7 @@ class PRReviewer:
 
                 # publish the review
                 if get_settings().pr_reviewer.persistent_comment and not self.incremental.is_incremental:
-                    self.git_provider.publish_persistent_review(pr_comment)
+                    self.git_provider.publish_persistent_comment(pr_comment)
                 else:
                     self.git_provider.publish_comment(pr_comment)
 

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -117,7 +117,13 @@ class PRReviewer:
             if get_settings().config.publish_output:
                 get_logger().info('Pushing PR review...')
                 previous_review_comment = self._get_previous_review_comment()
-                self.git_provider.publish_comment(pr_comment)
+
+                # publish the review
+                if get_settings().pr_reviewer.persistent_comment and not self.incremental.is_incremental:
+                    self.git_provider.publish_persistent_review(pr_comment)
+                else:
+                    self.git_provider.publish_comment(pr_comment)
+
                 self.git_provider.remove_initial_comment()
                 if previous_review_comment:
                     self._remove_previous_review_comment(previous_review_comment)
@@ -156,7 +162,6 @@ class PRReviewer:
         variables["diff"] = self.patches_diff  # update diff
 
         environment = Environment(undefined=StrictUndefined)
-        # set_custom_labels(variables)
         system_prompt = environment.from_string(get_settings().pr_review_prompt.system).render(variables)
         user_prompt = environment.from_string(get_settings().pr_review_prompt.user).render(variables)
 


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new feature to the PR Agent, allowing it to publish persistent reviews. The main changes include:
- Added a new method `publish_persistent_review` in the abstract `git_provider` class and its implementations in `bitbucket_provider`, `github_provider`, and `gitlab_provider`.
- Updated the `run` method in `pr_reviewer` to use the new `publish_persistent_review` method based on the configuration.
- Updated the configuration file to include a new setting for enabling persistent comments.
- Updated the documentation and usage files to reflect these changes.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `pr_agent/git_providers/bitbucket_provider.py`: Added a new method `publish_persistent_review` to update existing PR comments with the new review.
- `pr_agent/git_providers/github_provider.py`: Implemented the `publish_persistent_review` method to edit existing PR comments with the new review.
- `pr_agent/git_providers/gitlab_provider.py`: Implemented the `publish_persistent_review` method to update existing merge request notes with the new review.
- `pr_agent/git_providers/git_provider.py`: Added an abstract method `publish_persistent_review` to the base git provider class.
- `pr_agent/tools/pr_reviewer.py`: Updated the `run` method to use the new `publish_persistent_review` method based on the configuration.
- `pr_agent/settings/configuration.toml`: Added a new setting `persistent_comment` to enable or disable persistent comments.
- `docs/REVIEW.md`: Updated the documentation to include the new `persistent_comment` setting.
- `Usage.md`: Fixed a typo and updated the usage instructions to reflect the new feature.
- `RELEASE_NOTES.md`: Added a note about the new persistent comments feature to the unreleased section.
</details>
