### PR TITLE
Specify Cache Directory in Azure DevOps in Lambda Function Setup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -289,7 +289,8 @@ docker push codiumai/pr-agent:github_app  # Push to your Docker repository
     ```
 4. Create a lambda function that uses the uploaded image. Set the lambda timeout to be at least 3m.
 5. Configure the lambda function to have a Function URL.
-6. Go back to steps 8-9 of [Method 5](#run-as-a-github-app) with the function url as your Webhook URL.
+6. In the environment variables of the Lambda function, specify `AZURE_DEVOPS_CACHE_DIR` to a writable location such as /tmp. (see [#443](https://github.com/Codium-ai/pr-agent/issues/443))
+7. Go back to steps 8-9 of [Method 5](#run-as-a-github-app) with the function url as your Webhook URL.
     The Webhook URL would look like `https://<LAMBDA_FUNCTION_URL>/api/v1/github_webhooks`
 
 ---


### PR DESCRIPTION
## PR Type:
Documentation

___
## PR Description:
This PR updates the documentation to include an additional step in the Lambda function setup process. The new step instructs users to specify the `AZURE_DEVOPS_CACHE_DIR` environment variable in the Lambda function to a writable location such as /tmp. This change is in response to issue #443.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `INSTALL.md`: Added a new step in the Lambda function setup process instructing users to specify the `AZURE_DEVOPS_CACHE_DIR` environment variable to a writable location. The step numbering was also updated accordingly.
</details>
