### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -157,10 +157,11 @@ jobs:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
-2. Add the following secret to your repository under `Settings > Secrets`:
+2. Add the following secret to your repository under `Settings > Secrets and variables > Actions > New repository secret > Add secret`:
 
 ```
-OPENAI_KEY: <your key>
+Name = OPENAI_KEY
+Secret = <your key>
 ```
 
 The GITHUB_TOKEN secret is automatically created by GitHub.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -455,6 +455,6 @@ docker push codiumai/pr-agent:bitbucket_server_webhook  # Push to your Docker re
 Navigate to `Projects` or `Repositories`, `Settings`, `Webhooks`, `Create Webhook`.
 Fill the name and URL, Authentication None select the Pull Request Opened checkbox to receive that event as webhook.
 
-The url should end with `/webhook`, for example: https://domain.com/webhook
+The URL should end with `/webhook`, for example: https://domain.com/webhook
 
 =======

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -455,6 +455,6 @@ docker push codiumai/pr-agent:bitbucket_server_webhook  # Push to your Docker re
 Navigate to `Projects` or `Repositories`, `Settings`, `Webhooks`, `Create Webhook`.
 Fill the name and URL, Authentication None select the Pull Request Opened checkbox to receive that event as webhook.
 
-The url should be ends with `/webhook`, example: https://domain.com/webhook
+The url should end with `/webhook`, for example: https://domain.com/webhook
 
 =======


### PR DESCRIPTION
## Original Sentence 1
Add the following secret to your repository under `Settings > Secrets`:

## Issues in the Original Sentence 1
On Github, the user interface flow has changed, so this current documentation is outdated and misleading. Hence, the user feels a bit lost. It also confuses a junior developer leveraging the Github action tool for the first time. This can limit them or others from using the PR-agent tool altogether since the documentation feels misleading. 

## Final Sentence 1
Add the following secret to your repository under `Settings > Secrets and variables > Actions > New repository secret > Add secret`:

This new documentation provides a new guide based on Github's current user interface flow so users can set up their secrets without feeling lost.

## Original Sentence 2
```
OPENAI_KEY: <your key>
```

## Issues in the Original Sentence 2
Though the sentence represents a key, value pair, it is a bit misleading in a subtle way. This is because the previous instruction makes the reader assume that they are being instructed based on a graphic user interface (GUI) perspective. They start to feel lost on how to represent their value when they are presented with this original sentence, especially new developers.

## Final Sentence 2
```
Name = OPENAI_KEY
Secret = <your key>
```

This new sentence maintains the perspective that the reader is being instructed based on the GUI.

## Original Sentence 3
The url should be ends with `/webhook`, example: https://domain.com/webhook

## Issues in the Original Sentence 3
It's more concise and grammatically accurate to use the phrase "should end with" instead of "should be ends with." The verb "end" already implies a state of conclusion or termination, making the additional "be" unnecessary. Therefore, to convey the intended meaning more clearly and efficiently, it is recommended to say, "The URL should end with /webhook."

Here, “for example:” is used appropriately to introduce and connect the example to the preceding information. It helps guide the reader by signaling that the URL following it is an illustration of what was mentioned earlier. 

Lastly, “url” doesn't properly outline that this is an acronym for Uniform Resource Locator. Using “URL” helps maintain consistency and readability in technical writing.

## Final Sentence 3
The URL should end with `/webhook`, for example: https://domain.com/webhook