### PR TITLE
feat: add PR analysis review config option

### DIFF
--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -18,6 +18,7 @@ Under the section 'pr_reviewer', the [configuration file](./../pr_agent/settings
 
 #### enable\\disable features
 - `require_focused_review`: if set to true, the tool will add a section - 'is the PR a focused one'. Default is false.
+- `require_pr_analysis_review`: if set to trye, the tool will add an initial comment with an alalysis and summary of the PR. Default is true.
 - `require_score_review`: if set to true, the tool will add a section that scores the PR. Default is false.
 - `require_tests_review`: if set to true, the tool will add a section that checks if the PR contains tests. Default is true.
 - `require_security_review`: if set to true, the tool will add a section that checks if the PR contains security issues. Default is true.
@@ -32,7 +33,7 @@ Under the section 'pr_reviewer', the [configuration file](./../pr_agent/settings
 #### review labels
 - `enable_review_labels_security`: if set to true, the tool will publish a 'possible security issue' label if it detects a security issue. Default is true.
 - `enable_review_labels_effort`: if set to true, the tool will publish a 'Review effort [1-5]: x' label. Default is false.
-- To enable `custom labels`, apply the configuration changes described [here](./GENERATE_CUSTOM_LABELS.md#configuration-changes) 
+- To enable `custom labels`, apply the configuration changes described [here](./GENERATE_CUSTOM_LABELS.md#configuration-changes)
 ####  Incremental Mode
 For an incremental review, which only considers changes since the last PR-Agent review, this can be useful when working on the PR in an iterative manner, and you want to focus on the changes since the last review instead of reviewing the entire PR again, the following command can be used:
 ```
@@ -42,13 +43,13 @@ Note that the incremental mode is only available for GitHub.
 
 <kbd><img src=./../pics/incremental_review.png width="768"></kbd>
 
-Under the section 'pr_reviewer', the [configuration file](./../pr_agent/settings/configuration.toml#L16) contains options to customize the 'review -i' tool.  
+Under the section 'pr_reviewer', the [configuration file](./../pr_agent/settings/configuration.toml#L16) contains options to customize the 'review -i' tool.
 These configurations can be used to control the rate at which the incremental review tool will create new review comments when invoked automatically, to prevent making too much noise in the PR.
 - `minimal_commits_for_incremental_review`: Minimal number of commits since the last review that are required to create incremental review.
 If there are less than the specified number of commits since the last review, the tool will not perform any action.
 Default is 0 - the tool will always run, no matter how many commits since the last review.
 - `minimal_minutes_for_incremental_review`: Minimal number of minutes that need to pass since the last reviewed commit to create incremental review.
-If less that the specified number of minutes have passed between the last reviewed commit and running this command, the tool will not perform any action. 
+If less that the specified number of minutes have passed between the last reviewed commit and running this command, the tool will not perform any action.
 Default is 0 - the tool will always run, no matter how much time have passed since the last reviewed commit.
 - `require_all_thresholds_for_incremental_review`: If set to true, all the previous thresholds must be met for incremental review to run. If false, only one is enough to run the tool.
 For example, if `minimal_commits_for_incremental_review=2` and `minimal_minutes_for_incremental_review=2`, and we have 3 commits since the last review, but the last reviewed commit is from 1 minute ago:

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -18,7 +18,7 @@ Under the section 'pr_reviewer', the [configuration file](./../pr_agent/settings
 
 #### enable\\disable features
 - `require_focused_review`: if set to true, the tool will add a section - 'is the PR a focused one'. Default is false.
-- `require_pr_analysis_review`: if set to trye, the tool will add an initial comment with an alalysis and summary of the PR. Default is true.
+- `require_pr_analysis_review`: if set to true, the tool will add an initial comment with an analysis and summary of the PR. Default is true.
 - `require_score_review`: if set to true, the tool will add a section that scores the PR. Default is false.
 - `require_tests_review`: if set to true, the tool will add a section that checks if the PR contains tests. Default is true.
 - `require_security_review`: if set to true, the tool will add a section that checks if the PR contains security issues. Default is true.

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -43,6 +43,7 @@ Extra instructions from the user:
 
 You must use the following YAML schema to format your answer:
 ```yaml
+{%- if require_pr_analysis %}
 PR Analysis:
   Main theme:
     type: string
@@ -59,6 +60,7 @@ PR Analysis:
       - Enhancement
       - Documentation
       - Other
+{%- endif %}
 {%- if require_score %}
   Score:
     type: int

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -54,6 +54,7 @@ class PRReviewer:
             "description": self.git_provider.get_pr_description(),
             "language": self.main_language,
             "diff": "",  # empty diff for initial calculation
+            "require_pr_analysis": get_settings().pr_reviewer.require_pr_analysis_review,
             "require_score": get_settings().pr_reviewer.require_score_review,
             "require_tests": get_settings().pr_reviewer.require_tests_review,
             "require_security": get_settings().pr_reviewer.require_security_review,
@@ -119,7 +120,10 @@ class PRReviewer:
                 previous_review_comment = self._get_previous_review_comment()
 
                 # publish the review
-                if get_settings().pr_reviewer.persistent_comment and not self.incremental.is_incremental:
+                if ( get_settings().pr_reviewer.persistent_comment
+                and get_settings().pr_reviewer.require_pr_analysis_review
+                and not self.incremental.is_incremental
+                ):
                     self.git_provider.publish_persistent_comment(pr_comment,
                                                                  initial_header="## PR Analysis",
                                                                  update_header=True)


### PR DESCRIPTION
Added a new review setting that allows you to turn off the pr analysis when executing the review action. The default is true.

I'm running this agent from a container locally and would like to review PR's by only providing comments on the code instead of commenting a whole section that contains a PR summary and analysis. that's why I created this option to disable it.