### PR TITLE
Enhance pr_url assignment in github_provider.py for GitHub Actions compatibility

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -31,10 +31,10 @@ class GithubProvider(GitProvider):
         self.diff_files = None
         self.git_files = None
         self.incremental = incremental
-        self.pr_url = pr_url
         if pr_url and 'pull' in pr_url:
             self.set_pr(pr_url)
             self.last_commit_id = list(self.pr.get_commits())[-1]
+            self.pr_url = self.get_pr_url() # pr_url for github actions can be as api.github.com, so we need to get the url from the pr object
 
     def is_supported(self, capability: str) -> bool:
         return True


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR enhances the functionality of the `github_provider.py` script to improve compatibility with GitHub Actions. The main change is the update of the `pr_url` assignment. Previously, the `pr_url` was directly assigned from the input argument. Now, if a pull request URL is provided and it contains 'pull', the script sets the pull request and the `last_commit_id`, and then retrieves the `pr_url` from the pull request object. This change is necessary because the `pr_url` for GitHub Actions can be in the form of `api.github.com`, so it's more reliable to get the URL directly from the pull request object.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `pr_agent/git_providers/github_provider.py`: The `pr_url` assignment has been updated. If a pull request URL is provided and it contains 'pull', the script now sets the pull request and the `last_commit_id`, and then retrieves the `pr_url` from the pull request object. This change improves compatibility with GitHub Actions. A new method `get_pr_url` has been added to construct the PR URL from the repository and PR number.
</details>
