### PR TITLE
Drop support for python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 ]
 description = "CodiumAI PR-Agent is an open-source tool to automatically analyze a pull request and provide several types of feedback"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["ai", "tool", "developer", "review", "agent"]
 license = {file = "LICENSE", name = "Apache 2.0 License"}
 classifiers = [


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR updates the required Python version for the project. The change is made in the `pyproject.toml` file:
- The `requires-python` version has been updated from ">=3.9" to ">=3.10". This is due to the use of structural pattern matching in `bitbucket_server_provider.py`, which was introduced in Python 3.10.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pyproject.toml<br><br>

**The `requires-python` version has been updated from ">=3.9" <br>to ">=3.10".**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/560/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
The `bitbucket_server_provider.py` uses structural pattern matching that was introduced in python 3.10, and so trying to run any command with python 3.9 will fail (because we import all the providers right at the top of `pr_agent.git_providers`)
