### PR TITLE
Refine the prompt for `add_docs` command

### DIFF
--- a/pr_agent/settings/pr_add_docs.toml
+++ b/pr_agent/settings/pr_add_docs.toml
@@ -69,6 +69,7 @@ Code Documentation:
         - after
       description: |-
         The {{ docs_for_language }} placement relative to the relevant line (code component).
+        For example, in Python the docs are placed after the function signature, but in Java they are placed before.
     documentation:
       type: string
       description: |-


### PR DESCRIPTION
## Type
Enhancement


___

## Description
- Enhanced the description of the `enum` field in the `pr_agent/settings/pr_add_docs.toml` file to provide a clear example of how documentation placement varies in different programming languages, such as Python and Java.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_add_docs.toml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pr_agent/settings/pr_add_docs.toml<br><br>

**Added an example in the description of the `enum` field to <br>clarify the placement of documentation in different <br>programming languages.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/563/files#diff-27056b83691901e90900a125d483a0197c53dfd81766e02582847551ed313169"> +1/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
I found that without it, python docstrings are sometimes suggested above the function signature, instead of below.
