### PR TITLE
Fix failing `/config` command

### DIFF
--- a/pr_agent/tools/pr_config.py
+++ b/pr_agent/tools/pr_config.py
@@ -7,7 +7,7 @@ class PRConfig:
     """
     The PRConfig class is responsible for listing all configuration options available for the user.
     """
-    def __init__(self, pr_url: str, args=None):
+    def __init__(self, pr_url: str, args=None, ai_handler=None):
         """
         Initialize the PRConfig object with the necessary attributes and objects to comment on a pull request.
 


### PR DESCRIPTION
## Type
bug_fix


___

## Description
This PR addresses a bug in the `PRConfig` class where the `__init__` method was missing the `ai_handler` argument. This was causing a TypeError when trying to instantiate the `PRConfig` class. The changes in this PR include:
- Addition of `ai_handler` as a parameter to the `__init__` method in the `PRConfig` class.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_config.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pr_agent/tools/pr_config.py<br><br>

**The `__init__` method of the `PRConfig` class has been <br>updated to include an additional parameter `ai_handler`. <br>This change fixes a TypeError that was being raised due to <br>the missing `ai_handler` argument.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/566/files#diff-25869e6550244c0be5d366dfa8ed6c3f21cfff07fe86165075d3c06a94c0ee4d"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
All commands need the `ai_handler` argument. The PRConfig class was missing it in the `__init__` method and so it failed with this error:

```
File "/home/vcap/app/pr_agent/agent/pr_agent.py", line 76, in handle_request
    await command2class[action](pr_url, ai_handler=self.ai_handler, args=args).run()
TypeError: PRConfig.__init__() got an unexpected keyword argument 'ai_handler'
```
