### PR TITLE
Tr/describe bullets

### DIFF
--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -415,6 +415,7 @@ class PRDescription:
 
 </details>
     
+
   </td>
   <td><a href="{link}">{diff_plus_minus}</a>{delta_nbsp}</td>
 </tr>                    
@@ -470,10 +471,6 @@ def insert_br_after_x_chars(text, x=70):
         is_saved_word = False
         if word == "<code>" or word == "</code>" or word == "<li>" or word == "<br>":
             is_saved_word = True
-        if "<code>" in word:
-            is_inside_code = True
-        if  "</code>" in word:
-            is_inside_code = False
 
         len_word = count_chars_without_html(word)
         if not is_saved_word and (current_length + len_word > x):
@@ -490,6 +487,10 @@ def insert_br_after_x_chars(text, x=70):
         if word == "<li>" or word == "<br>":
             current_length = 0
 
+        if "<code>" in word:
+            is_inside_code = True
+        if "</code>" in word:
+            is_inside_code = False
     return ''.join(new_text).strip()
 
 def replace_code_tags(text):

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -411,7 +411,10 @@ class PRDescription:
 
 {filename}
 {file_change_description_br}
-    </details>
+
+
+</details>
+    
   </td>
   <td><a href="{link}">{diff_plus_minus}</a>{delta_nbsp}</td>
 </tr>                    

--- a/tests/unittest/test_convert_to_markdown.py
+++ b/tests/unittest/test_convert_to_markdown.py
@@ -112,9 +112,17 @@ class TestBR:
                                    'ColorPaletteResourcesCollection ColorPaletteResourcesCollection`')
         file_change_description_br = insert_br_after_x_chars(file_change_description)
         expected_output = ('<li>Created a - new -class <code>ColorPaletteResourcesCollection </code><br><code>'
-                           'ColorPaletteResourcesCollection ColorPaletteResourcesCollection <br>'
-                           'ColorPaletteResourcesCollection</code>')
+                           'ColorPaletteResourcesCollection ColorPaletteResourcesCollection '
+                           '</code><br><code>ColorPaletteResourcesCollection</code>')
         assert file_change_description_br == expected_output
         # print("-----")
         # print(file_change_description_br)
 
+    def test_br3(self):
+        file_change_description = 'Created a new class `ColorPaletteResourcesCollection` which extends `AvaloniaDictionary<ThemeVariant, ColorPaletteResources>` and implements aaa'
+        file_change_description_br = insert_br_after_x_chars(file_change_description)
+        assert file_change_description_br == ('Created a new class <code>ColorPaletteResourcesCollection</code> which '
+                                              'extends <br><code>AvaloniaDictionary<ThemeVariant, ColorPaletteResources>'
+                                              '</code> and implements <br>aaa')
+        # print("-----")
+        # print(file_change_description_br)


### PR DESCRIPTION
## **Type**
Bug fix, Tests


___

## **Description**
- The PR mainly focuses on refactoring the code in 'pr_agent/tools/pr_description.py' and updating the test cases in 'tests/unittest/test_convert_to_markdown.py'.
- In 'pr_agent/tools/pr_description.py', the code that checks for "<code>" and "</code>" in a word has been moved after the check for "<li>" or "<br>". This change ensures that the "<code>" and "</code>" tags are handled correctly.
- In 'tests/unittest/test_convert_to_markdown.py', a new test case 'test_br3' has been added to check the functionality of 'insert_br_after_x_chars' function. Also, the expected output in 'test_br2' test case has been modified.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description.py</strong><dd><code>Refactor code and remove unnecessary blank lines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/tools/pr_description.py

- Moved the code that checks for "<code>" and "</code>" in a word after <br>  the check for "<li>" or "<br>".<br> - Removed unnecessary blank lines.

    </details>
  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/639/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_convert_to_markdown.py</strong><dd><code>Update test cases in test_convert_to_markdown.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/unittest/test_convert_to_markdown.py

- Added a new test case 'test_br3' to check the functionality of <br>  'insert_br_after_x_chars' function.<br> - Modified the expected output in 'test_br2' test case.

    </details>
  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/639/files#diff-48e28c70a7fa0ad268cc0cd35739816da980187199079f2c78eeffff330ce450">+10/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
