### PR TITLE
filter events to align with pr-agent's setting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,6 +126,8 @@ on:
     types:
       - opened
       - reopened
+      - ready_for_review
+      - review_requested
 
   issue_comment:
     types:
@@ -154,6 +156,8 @@ on:
     types:
       - opened
       - reopened
+      - ready_for_review
+      - review_requested
 
   issue_comment:
     types:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -123,7 +123,14 @@ You can use our pre-built Github Action Docker image to run PR-Agent as a Github
 ```yaml
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+
   issue_comment:
+    types:
+      - created
+      - edited
 jobs:
   pr_agent_job:
     runs-on: ubuntu-latest
@@ -144,7 +151,14 @@ jobs:
 ```yaml
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+
   issue_comment:
+    types:
+      - created
+      - edited
 
 jobs:
   pr_agent_job:


### PR DESCRIPTION
Related to https://github.com/Codium-ai/pr-agent/issues/648

The document was a little confusing, because it runs the GitHub Action on 'synchronize', but pr-agent was not executed due to the following code.

https://github.com/Codium-ai/pr-agent/blob/e4f177908b620e46740b03966fda9243473d979e/pr_agent/servers/github_action_runner.py#L82

This change makes it aligned with the code.