### PR TITLE
check ci

### DIFF
--- a/tests/unittest/test_file_filter.py
+++ b/tests/unittest/test_file_filter.py
@@ -14,7 +14,7 @@ class TestIgnoreFilter:
             type('', (object,), {'filename': 'file4.py'})(),
             type('', (object,), {'filename': 'file5.py'})()
         ]
-        assert filter_ignored(files) == files, "Expected all files to be returned when no ignore patterns are given."
+        assert filter_ignored(files) == None, "Expected all files to be returned when no ignore patterns are given."
 
     def test_glob_ignores(self, monkeypatch):
         """


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixed an incorrect assertion in `test_no_ignores` within `test_file_filter.py`. The test now expects `None` instead of all files when no ignore patterns are given, aligning the test expectation with the updated logic.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_file_filter.py</strong><dd><code>Fix Expected Result in Test for File Filtering Without Ignore Patterns</code></dd></summary>
<hr>
      
tests/unittest/test_file_filter.py

<li>Modified the expected result in <code>test_no_ignores</code> to <code>None</code> from <code>files</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/670/files#diff-3027c17fd045d59c760cb3fd8b6ce72c3e333667ed2466acb99a3f5c3faa2803">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

