### PR TITLE
Added PRHelpMessage to command execution in pr_agent.py

### DIFF
--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -13,6 +13,7 @@ from pr_agent.tools.pr_code_suggestions import PRCodeSuggestions
 from pr_agent.tools.pr_config import PRConfig
 from pr_agent.tools.pr_description import PRDescription
 from pr_agent.tools.pr_generate_labels import PRGenerateLabels
+from pr_agent.tools.pr_help_message import PRHelpMessage
 from pr_agent.tools.pr_information_from_user import PRInformationFromUser
 from pr_agent.tools.pr_line_questions import PR_LineQuestions
 from pr_agent.tools.pr_questions import PRQuestions
@@ -37,6 +38,7 @@ command2class = {
     "update_changelog": PRUpdateChangelog,
     "config": PRConfig,
     "settings": PRConfig,
+    "help": PRHelpMessage,
     "similar_issue": PRSimilarIssue,
     "add_docs": PRAddDocs,
     "generate_labels": PRGenerateLabels,

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -34,22 +34,3 @@ class PRHelpMessage:
         except Exception as e:
             get_logger().error(f"Error while running PRHelpMessage: {e}")
         return ""
-
-    def _prepare_pr_configs(self) -> str:
-        import tomli
-        with open(get_settings().find_file("configuration.toml"), "rb") as conf_file:
-            configuration_headers = [header.lower() for header in tomli.load(conf_file).keys()]
-        relevant_configs = {
-            header: configs for header, configs in get_settings().to_dict().items()
-            if header.lower().startswith("pr_") and header.lower() in configuration_headers
-        }
-        comment_str = "Possible Configurations:"
-        for header, configs in relevant_configs.items():
-            if configs:
-                comment_str += "\n"
-            for key, value in configs.items():
-                comment_str += f"\n{header.lower()}.{key.lower()} = {repr(value) if isinstance(value, str) else value}"
-                comment_str += "  "
-        if get_settings().config.verbosity_level >= 2:
-            get_logger().info(f"comment_str:\n{comment_str}")
-        return comment_str

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -8,38 +8,34 @@ class PRHelpMessage:
     The PRConfig class is responsible for listing all configuration options available for the user.
     """
     def __init__(self, pr_url: str, args=None, ai_handler=None):
-        """
-        Initialize the PRConfig object with the necessary attributes and objects to comment on a pull request.
-
-        Args:
-            pr_url (str): The URL of the pull request to be reviewed.
-            args (list, optional): List of arguments passed to the PRReviewer class. Defaults to None.
-        """
         self.git_provider = get_git_provider()(pr_url)
 
     async def run(self):
-        get_logger().info('Getting PR Help Message...')
-        pr_comment="## PR Agent Intro\n\n"
-        pr_comment +="🤖 Welcome to the PR Agent, an AI-powered tool for automated pull request analysis, feedback, suggestions and more."""
-        pr_comment +="\n\nHere are the tools you can use to interact with the PR Agent:\n"
-        base_path ="https://github.com/Codium-ai/pr-agent/tree/main/docs"
-        pr_comment +=f"""
-\n\n
-- [DESCRIBE]({base_path}/DESCRIBE.md)
-- [REVIEW]({base_path}/REVIEW.md)
-- [IMPROVE](./IMPROVE.md)
-- [ASK]({base_path}/ASK.md)
-- [SIMILAR_ISSUE]({base_path}/SIMILAR_ISSUE.md)
-- [UPDATE CHANGELOG]({base_path}/UPDATE_CHANGELOG.md)
-- [ADD DOCUMENTATION]({base_path}/ADD_DOCUMENTATION.md)
-- [GENERATE CUSTOM LABELS]({base_path}/GENERATE_CUSTOM_LABELS.md)
-- [Analyze]({base_path}/Analyze.md)
-- [Test]({base_path}/TEST.md)
-- [CI Feedback]({base_path}/CI_FEEDBACK.md)
-"""
-        pr_comment +=f"""\n\nNote that each command be [applied automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools-for-pr-actions) when a new PR is opened, or invoked manually by [commenting on a PR](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#online-usage)."""
-        if get_settings().config.publish_output:
-            self.git_provider.publish_comment(pr_comment)
+        try:
+            get_logger().info('Getting PR Help Message...')
+            pr_comment="## PR Agent Intro\n\n"
+            pr_comment +="🤖 Welcome to the PR Agent, an AI-powered tool for automated pull request analysis, feedback, suggestions and more."""
+            pr_comment +="\n\nHere are the tools you can use to interact with the PR Agent:\n"
+            base_path ="https://github.com/Codium-ai/pr-agent/tree/main/docs"
+            pr_comment +=f"""
+    \n\n
+    - [DESCRIBE]({base_path}/DESCRIBE.md)
+    - [REVIEW]({base_path}/REVIEW.md)
+    - [IMPROVE]({base_path}/IMPROVE.md)
+    - [ASK]({base_path}/ASK.md)
+    - [SIMILAR_ISSUE]({base_path}/SIMILAR_ISSUE.md)
+    - [UPDATE CHANGELOG]({base_path}/UPDATE_CHANGELOG.md)
+    - [ADD DOCUMENTATION]({base_path}/ADD_DOCUMENTATION.md)
+    - [GENERATE CUSTOM LABELS]({base_path}/GENERATE_CUSTOM_LABELS.md)
+    - [Analyze]({base_path}/Analyze.md)
+    - [Test]({base_path}/TEST.md)
+    - [CI Feedback]({base_path}/CI_FEEDBACK.md)
+    """
+            pr_comment +=f"""\n\nNote that each command be [applied automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools-for-pr-actions) when a new PR is opened, or invoked manually by [commenting on a PR](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#online-usage)."""
+            if get_settings().config.publish_output:
+                self.git_provider.publish_comment(pr_comment)
+        except Exception as e:
+            get_logger().error(f"Error while running PRHelpMessage: {e}")
         return ""
 
     def _prepare_pr_configs(self) -> str:

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -1,0 +1,62 @@
+from pr_agent.config_loader import get_settings
+from pr_agent.git_providers import get_git_provider
+from pr_agent.log import get_logger
+
+
+class PRHelpMessage:
+    """
+    The PRConfig class is responsible for listing all configuration options available for the user.
+    """
+    def __init__(self, pr_url: str, args=None, ai_handler=None):
+        """
+        Initialize the PRConfig object with the necessary attributes and objects to comment on a pull request.
+
+        Args:
+            pr_url (str): The URL of the pull request to be reviewed.
+            args (list, optional): List of arguments passed to the PRReviewer class. Defaults to None.
+        """
+        self.git_provider = get_git_provider()(pr_url)
+
+    async def run(self):
+        get_logger().info('Getting PR Help Message...')
+        pr_comment="## PR Agent Intro\n\n"
+        pr_comment +="🤖 Welcome to the PR Agent, an AI-powered tool for automated pull request analysis, feedback, suggestions and more."""
+        pr_comment +="\n\nHere are the tools you can use to interact with the PR Agent:\n"
+        base_path ="https://github.com/Codium-ai/pr-agent/tree/main/docs"
+        pr_comment +=f"""
+\n\n
+- [DESCRIBE]({base_path}/DESCRIBE.md)
+- [REVIEW]({base_path}/REVIEW.md)
+- [IMPROVE](./IMPROVE.md)
+- [ASK]({base_path}/ASK.md)
+- [SIMILAR_ISSUE]({base_path}/SIMILAR_ISSUE.md)
+- [UPDATE CHANGELOG]({base_path}/UPDATE_CHANGELOG.md)
+- [ADD DOCUMENTATION]({base_path}/ADD_DOCUMENTATION.md)
+- [GENERATE CUSTOM LABELS]({base_path}/GENERATE_CUSTOM_LABELS.md)
+- [Analyze]({base_path}/Analyze.md)
+- [Test]({base_path}/TEST.md)
+- [CI Feedback]({base_path}/CI_FEEDBACK.md)
+"""
+        pr_comment +=f"""\n\nNote that each command be [applied automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools-for-pr-actions) when a new PR is opened, or invoked manually by [commenting on a PR](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#online-usage)."""
+        if get_settings().config.publish_output:
+            self.git_provider.publish_comment(pr_comment)
+        return ""
+
+    def _prepare_pr_configs(self) -> str:
+        import tomli
+        with open(get_settings().find_file("configuration.toml"), "rb") as conf_file:
+            configuration_headers = [header.lower() for header in tomli.load(conf_file).keys()]
+        relevant_configs = {
+            header: configs for header, configs in get_settings().to_dict().items()
+            if header.lower().startswith("pr_") and header.lower() in configuration_headers
+        }
+        comment_str = "Possible Configurations:"
+        for header, configs in relevant_configs.items():
+            if configs:
+                comment_str += "\n"
+            for key, value in configs.items():
+                comment_str += f"\n{header.lower()}.{key.lower()} = {repr(value) if isinstance(value, str) else value}"
+                comment_str += "  "
+        if get_settings().config.verbosity_level >= 2:
+            get_logger().info(f"comment_str:\n{comment_str}")
+        return comment_str

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -4,9 +4,6 @@ from pr_agent.log import get_logger
 
 
 class PRHelpMessage:
-    """
-    The PRConfig class is responsible for listing all configuration options available for the user.
-    """
     def __init__(self, pr_url: str, args=None, ai_handler=None):
         self.git_provider = get_git_provider()(pr_url)
 

--- a/pr_agent/tools/pr_help_message.py
+++ b/pr_agent/tools/pr_help_message.py
@@ -14,20 +14,20 @@ class PRHelpMessage:
             pr_comment +="🤖 Welcome to the PR Agent, an AI-powered tool for automated pull request analysis, feedback, suggestions and more."""
             pr_comment +="\n\nHere are the tools you can use to interact with the PR Agent:\n"
             base_path ="https://github.com/Codium-ai/pr-agent/tree/main/docs"
-            pr_comment +=f"""
-    \n\n
-    - [DESCRIBE]({base_path}/DESCRIBE.md)
-    - [REVIEW]({base_path}/REVIEW.md)
-    - [IMPROVE]({base_path}/IMPROVE.md)
-    - [ASK]({base_path}/ASK.md)
-    - [SIMILAR_ISSUE]({base_path}/SIMILAR_ISSUE.md)
-    - [UPDATE CHANGELOG]({base_path}/UPDATE_CHANGELOG.md)
-    - [ADD DOCUMENTATION]({base_path}/ADD_DOCUMENTATION.md)
-    - [GENERATE CUSTOM LABELS]({base_path}/GENERATE_CUSTOM_LABELS.md)
-    - [Analyze]({base_path}/Analyze.md)
-    - [Test]({base_path}/TEST.md)
-    - [CI Feedback]({base_path}/CI_FEEDBACK.md)
-    """
+            pr_comment +=f"""\
+\n\n
+- [DESCRIBE]({base_path}/DESCRIBE.md)
+- [REVIEW]({base_path}/REVIEW.md)
+- [IMPROVE]({base_path}/IMPROVE.md)
+- [ASK]({base_path}/ASK.md)
+- [SIMILAR_ISSUE]({base_path}/SIMILAR_ISSUE.md)
+- [UPDATE CHANGELOG]({base_path}/UPDATE_CHANGELOG.md)
+- [ADD DOCUMENTATION]({base_path}/ADD_DOCUMENTATION.md)
+- [GENERATE CUSTOM LABELS]({base_path}/GENERATE_CUSTOM_LABELS.md)
+- [Analyze]({base_path}/Analyze.md)
+- [Test]({base_path}/TEST.md)
+- [CI Feedback]({base_path}/CI_FEEDBACK.md)
+"""
             pr_comment +=f"""\n\nNote that each command be [applied automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools-for-pr-actions) when a new PR is opened, or invoked manually by [commenting on a PR](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#online-usage)."""
             if get_settings().config.publish_output:
                 self.git_provider.publish_comment(pr_comment)


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a new `PRHelpMessage` class to provide automated help messages for PRs.
- Integrated `PRHelpMessage` into the PR Agent's command execution flow, allowing users to request help directly in PR comments.
- The help message includes links to documentation for various PR Agent tools, enhancing user guidance and support.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent.py</strong><dd><code>Integration of PRHelpMessage Command in Agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/agent/pr_agent.py

<li>Imported <code>PRHelpMessage</code> from <code>pr_agent.tools</code>.<br> <li> Added <code>help</code> command to the command execution mapping.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/673/files#diff-db2b038f914c88e292869242ae3c293765511994a83d72459642e81b5b741f47">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pr_help_message.py</strong><dd><code>Implementation of PRHelpMessage for Automated Help Responses</code></dd></summary>
<hr>
      
pr_agent/tools/pr_help_message.py

<li>Implemented <code>PRHelpMessage</code> class for generating help messages in PRs.<br> <li> The class fetches settings, prepares a help message, and publishes it <br>as a PR comment.<br> <li> Added documentation links for various PR Agent tools in the help <br>message.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/673/files#diff-6f30977025b20a27640fc33cfe2db79160753bd30c7879f60f2b5894d86f78de">+62/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
