### PR TITLE
Add a note about change the target for Gitlab install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -392,7 +392,7 @@ WEBHOOK_SECRET=$(python -c "import secrets; print(secrets.token_hex(10))")
     - Your OpenAI key.
     - In the [gitlab] section, fill in personal_access_token and shared_secret. The access token can be a personal access token, or a group or project access token.
     - Set deployment_type to 'gitlab' in [configuration.toml](./pr_agent/settings/configuration.toml)
-5. Create a webhook in GitLab. Set the URL to the URL of your app's server. Set the secret token to the generated secret from step 2.
+5. Create a webhook in GitLab. Set the URL to the URL of your app's server with the path `/webhook` (e.g. `http://pr-agent.example.com:3000/webhook`). Set the secret token to the generated secret from step 2.
 In the "Trigger" section, check the ‘comments’ and ‘merge request events’ boxes.
 6. Test your installation by opening a merge request or commenting on a merge request using one of CodiumAI's commands.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -387,14 +387,14 @@ PYTHONPATH="/PATH/TO/PROJECTS/pr-agent" python pr_agent/cli.py \
 ```
 WEBHOOK_SECRET=$(python -c "import secrets; print(secrets.token_hex(10))")
 ```
-3. Follow the instructions to build the Docker image, setup a secrets file and deploy on your own server from [Method 5](#run-as-a-github-app) steps 4-7.
+3. Follow the instructions to build the Docker image, setup a secrets file and deploy on your own server from [Method 5](#run-as-a-github-app) steps 4-7. Be sure to set the target to `gitlab_webhook` instead of `github_app` when building the Docker image.
 4. In the secrets file, fill in the following:
     - Your OpenAI key.
     - In the [gitlab] section, fill in personal_access_token and shared_secret. The access token can be a personal access token, or a group or project access token.
     - Set deployment_type to 'gitlab' in [configuration.toml](./pr_agent/settings/configuration.toml)
 5. Create a webhook in GitLab. Set the URL to the URL of your app's server. Set the secret token to the generated secret from step 2.
 In the "Trigger" section, check the ‘comments’ and ‘merge request events’ boxes.
-6. Test your installation by opening a merge request or commenting or a merge request using one of CodiumAI's commands.
+6. Test your installation by opening a merge request or commenting on a merge request using one of CodiumAI's commands.
 
 
 


### PR DESCRIPTION
## **User description**
This is just a minor documentation update about changing the target when building the Docker image for Gitlab.  While it's obvious in retrospect, if you jump straight to the Gitlab section of the document how this is supposed to work.  If you follow the directions exactly you run into [this issue](https://github.com/Codium-ai/pr-agent/issues/456).  Also adds more clarity to the URL to use for the webhook.


___

## **Type**
Documentation


___

## **Description**
- Updated the GitLab installation section in `INSTALL.md` to include a note about setting the target to `gitlab_webhook` when building the Docker image. This clarification aims to prevent confusion and issues when following the installation guide.
- Corrected a typo in the testing instructions, ensuring clarity in the steps to verify the setup.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>INSTALL.md</strong><dd><code>Update GitLab Installation Instructions and Fix Typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
INSTALL.md

<li>Added instruction to set the target to <code>gitlab_webhook</code> when building <br>the Docker image for GitLab.<br> <li> Fixed a typo in the instructions for testing the installation <br>("commenting on a merge request").<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/682/files#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

