### PR TITLE
Change github app startup logic to support gunicorj

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -292,3 +292,5 @@ app.include_router(router)
 def start():
     uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "3000")))
 
+if __name__ == '__main__':
+    start()

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -280,17 +280,15 @@ async def root():
     return {"status": "ok"}
 
 
-def start():
-    if get_settings().github_app.override_deployment_type:
-        # Override the deployment type to app
-        get_settings().set("GITHUB.DEPLOYMENT_TYPE", "app")
-    get_settings().set("CONFIG.PUBLISH_OUTPUT_PROGRESS", False)
-    middleware = [Middleware(RawContextMiddleware)]
-    app = FastAPI(middleware=middleware)
-    app.include_router(router)
+if get_settings().github_app.override_deployment_type:
+    # Override the deployment type to app
+    get_settings().set("GITHUB.DEPLOYMENT_TYPE", "app")
+get_settings().set("CONFIG.PUBLISH_OUTPUT_PROGRESS", False)
+middleware = [Middleware(RawContextMiddleware)]
+app = FastAPI(middleware=middleware)
+app.include_router(router)
 
+
+def start():
     uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "3000")))
 
-
-if __name__ == '__main__':
-    start()


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Refactored the GitHub app startup logic to better support Gunicorn by initializing the FastAPI app at the module level instead of within the `start` function.
- Removed the `if __name__ == '__main__':` block, streamlining execution when used with Gunicorn.
- Ensured settings related to GitHub app deployment type and progress publishing are set before the app starts.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_app.py</strong><dd><code>Refactor GitHub App Startup Logic for Gunicorn Support</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/servers/github_app.py

<li>Refactored the startup logic for the GitHub app to support Gunicorn <br>more effectively.<br> <li> Moved the app initialization outside of the <code>start</code> function to the <br>module level.<br> <li> Removed the conditional <code>start</code> invocation from the module's execution <br>block.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/701/files#diff-3fb3f174152732d1b69953c8bd81b8a0a30f0e42100dc626d932da8371851608">+9/-11</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

