### PR TITLE
Add documentation for 'ignore_pr_titles' parameter in Usage.md

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -174,6 +174,13 @@ To cancel the automatic run of all the tools, set:
 handle_pr_actions = []
 ```
 
+You can also disable automatic runs for PRs with specific titles, by setting the `ignore_pr_titles` parameter with the relevant regex. For example:
+```
+[github_app]
+ignore_pr_title = ["^[Auto]", ".*ignore.*"]
+```
+will ignore PRs with titles that start with "Auto" or contain the word "ignore".
+
 ##### GitHub app automatic tools for push actions (commits to an open PR)
 In addition to running automatic tools when a PR is opened, the GitHub app can also respond to new code that is pushed to an open PR.
 


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- Introduced documentation for the `ignore_pr_titles` parameter within the GitHub app configuration to ignore PRs based on title patterns.
- Examples demonstrate how to configure regex patterns to match specific PR titles that should be ignored.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Usage.md</strong><dd><code>Documenting `ignore_pr_titles` Parameter with Examples</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Usage.md

<li>Added documentation for the <code>ignore_pr_titles</code> parameter in the GitHub <br>app configuration section.<br> <li> Provided examples on how to use <code>ignore_pr_titles</code> to ignore PRs based <br>on their titles using regex patterns.<br>


</details>
    

  </td>
  <td><a href="https:/Codium-ai/pr-agent/pull/717/files#diff-98bbb2166f184dd69bb689271547bf3414ce37f682b1f51bd0efdb8b565ce99d">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

