### PR TITLE
Add Gitlab support for using an eyes emoji reaction when reviewing

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -368,11 +368,21 @@ class GitLabProvider(GitProvider):
         except Exception:
             return ""
 
-    def add_eyes_reaction(self, issue_comment_id: int, disable_eyes: bool = False) -> Optional[int]:
-        return True
+    def add_eyes_reaction(self) -> Optional[int]:
+      try:
+        emoji = self.mr.awardemojis.create({'name': 'eyes'})
+        return emoji
+      except Exception as e:
+        get_logger().exception(f"Failed to add eyes reaction, error: {e}")
+        return False
 
-    def remove_reaction(self, issue_comment_id: int, reaction_id: int) -> bool:
+    def remove_reaction(self, emoji) -> bool:
+      try:
+        emoji.delete()
         return True
+      except Exception as e:
+        get_logger().exception(f"Failed to remove eyes reaction, error: {e}")
+        return False
 
     def _parse_merge_request_url(self, merge_request_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(merge_request_url)

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -5,6 +5,7 @@ fallback_models=["gpt-3.5-turbo-16k"]
 git_provider="github"
 publish_output=true
 publish_output_progress=true
+use_eyes_for_progress=false # Only supported on Gitlab
 verbosity_level=0 # 0,1,2
 use_extra_bad_extensions=false
 use_repo_settings_file=true


### PR DESCRIPTION
This adds basic support for adding an eyes reaction rather than a message when a review is pending.  The default on Gitlab generates a lot of email.  I'm really new to this project, and not a Python dev by trade, so any suggestions or feedback on a better approach is welcome. 