### PR TITLE
fix

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -108,7 +108,7 @@ class PRReviewer:
                                 'config': dict(get_settings().config)}
             get_logger().debug("Relevant configs", artifacts=relevant_configs)
 
-            if self.incremental.is_incremental and hasattr(self.git_provider, "file_set") and not self.git_provider.unreviewed_files_set:
+            if self.incremental.is_incremental and hasattr(self.git_provider, "unreviewed_files_set") and not self.git_provider.unreviewed_files_set:
                 get_logger().info(f"Incremental review is enabled for {self.pr_url} but there are no new files")
                 previous_review_url = ""
                 if hasattr(self.git_provider, "previous_review"):


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Corrected the condition that checks for the presence of `unreviewed_files_set` in the git provider to ensure it functions as intended.
- This fix ensures that the system correctly logs when an incremental review is enabled but there are no new files to review, avoiding confusion.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer.py</strong><dd><code>Fix Incremental Review File Check and Logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/tools/pr_reviewer.py

<li>Fixed a condition to correctly check for <code>unreviewed_files_set</code> <br>attribute in the git provider.<br> <li> Added logging to inform when incremental review is enabled but no new <br>files are present.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/769/files#diff-8e265068e189a06852605cc694b03e92b523b4f8162077a2f3455ced4cdad8dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

