### PR TITLE
Initialize current_labels to empty list if no labels exist in pr_revi…

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -373,6 +373,8 @@ class PRReviewer:
                         review_labels.append('Possible security concern')
 
                 current_labels = self.git_provider.get_pr_labels(update=True)
+                if not current_labels:
+                    current_labels = []
                 get_logger().debug(f"Current labels:\n{current_labels}")
                 if current_labels:
                     current_labels_filtered = [label for label in current_labels if


### PR DESCRIPTION
## **User description**
…ewer.py


___

## **Type**
bug_fix


___

## **Description**
- Fixes an issue where `current_labels` was not initialized to an empty list if no labels were present, potentially causing errors in subsequent operations.
- Ensures that `current_labels` is always a list, improving the robustness of label handling.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer.py</strong><dd><code>Fix Uninitialized `current_labels` in PR Reviewer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/tools/pr_reviewer.py

<li>Initializes <code>current_labels</code> to an empty list if no labels exist.<br> <li> Adds a debug log to display the current labels.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/796/files#diff-8e265068e189a06852605cc694b03e92b523b4f8162077a2f3455ced4cdad8dc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

