### PR TITLE
Added `ignore_bot_pr` option

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -123,7 +123,7 @@ async def handle_new_pr_opened(body: Dict[str, Any],
                                agent: PRAgent):
     # logic to ignore PRs opened by bot
     if get_settings().get("GITHUB_APP.IGNORE_BOT_PR", False):
-       if re.match('.+\[bot]$', sender) is not None:
+       if sender.endswith('[bot]'):
            get_logger().info(f"Ignoring PR by sender '{sender}' due to github_app.ignore_bot_pr setting")
            return {}
 

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -118,14 +118,14 @@ async def handle_new_pr_opened(body: Dict[str, Any],
                                event: str,
                                sender: str,
                                sender_id: str,
+                               sender_type: str,
                                action: str,
                                log_context: Dict[str, Any],
                                agent: PRAgent):
     # logic to ignore PRs opened by bot
-    if get_settings().get("GITHUB_APP.IGNORE_BOT_PR", False):
-       if sender.endswith('[bot]'):
-           get_logger().info(f"Ignoring PR by sender '{sender}' due to github_app.ignore_bot_pr setting")
-           return {}
+    if get_settings().get("GITHUB_APP.IGNORE_BOT_PR", False) and sender_type == "Bot":
+        get_logger().info(f"Ignoring PR from '{sender=}' due to github_app.ignore_bot_pr setting")
+        return {}
 
     title = body.get("pull_request", {}).get("title", "")
 
@@ -230,9 +230,11 @@ def handle_closed_pr(body, event, action, log_context):
 def get_log_context(body, event, action, build_number):
     sender = ""
     sender_id = ""
+    sender_type = ""
     try:
         sender = body.get("sender", {}).get("login")
         sender_id = body.get("sender", {}).get("id")
+        sender_type = body.get("sender", {}).get("type")
         repo = body.get("repository", {}).get("full_name", "")
         git_org = body.get("organization", {}).get("login", "")
         app_name = get_settings().get("CONFIG.APP_NAME", "Unknown")
@@ -242,7 +244,7 @@ def get_log_context(body, event, action, build_number):
     except Exception as e:
         get_logger().error("Failed to get log context", e)
         log_context = {}
-    return log_context, sender, sender_id
+    return log_context, sender, sender_id, sender_type
 
 
 async def handle_request(body: Dict[str, Any], event: str):
@@ -257,7 +259,7 @@ async def handle_request(body: Dict[str, Any], event: str):
     if not action:
         return {}
     agent = PRAgent()
-    log_context, sender, sender_id = get_log_context(body, event, action, build_number)
+    log_context, sender, sender_id, sender_type = get_log_context(body, event, action, build_number)
 
     # handle comments on PRs
     if action == 'created':
@@ -266,7 +268,7 @@ async def handle_request(body: Dict[str, Any], event: str):
     # handle new PRs
     elif event == 'pull_request' and action != 'synchronize' and action != 'closed':
         get_logger().debug(f'Request body', artifact=body, event=event)
-        await handle_new_pr_opened(body, event, sender, sender_id, action, log_context, agent)
+        await handle_new_pr_opened(body, event, sender, sender_id, sender_type, action, log_context, agent)
     # handle pull_request event with synchronize action - "push trigger" for new commits
     elif event == 'pull_request' and action == 'synchronize':
         get_logger().debug(f'Request body', artifact=body, event=event)

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -121,6 +121,12 @@ async def handle_new_pr_opened(body: Dict[str, Any],
                                action: str,
                                log_context: Dict[str, Any],
                                agent: PRAgent):
+    # logic to ignore PRs opened by bot
+    if get_settings().get("GITHUB_APP.IGNORE_BOT_PR", False):
+       if re.match('.+\[bot]$', sender) is not None:
+           get_logger().info(f"Ignoring PR by sender '{sender}' due to github_app.ignore_bot_pr setting")
+           return {}
+
     title = body.get("pull_request", {}).get("title", "")
 
     # logic to ignore PRs with specific titles (e.g. "[Auto] ...")

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -155,6 +155,7 @@ push_commands = [
     "/review --pr_reviewer.num_code_suggestions=0",
 ]
 ignore_pr_title = []
+ignore_bot_pr = false
 
 [gitlab]
 url = "https://gitlab.com" # URL to the gitlab service


### PR DESCRIPTION
## **User description**
Add an option to ignore pull requests opend by bots such as `renovate[bot]`.

Discussion:
Which is preferable, ignoring bots entirely or allowing specification of users to ignore?


___

## **Type**
enhancement, configuration changes


___

## **Description**
- Introduced a new feature to ignore PRs opened by bots in the GitHub App mode, enhancing automation control.
- Added a new configuration option `ignore_bot_pr` in the settings to enable or disable ignoring bot-opened PRs.
- Updated `handle_new_pr_opened` and `get_log_context` functions to support checking the sender type and applying the new ignore bots logic.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_app.py</strong><dd><code>Support for Ignoring Bot-Opened PRs in GitHub App</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/servers/github_app.py

<li>Added <code>sender_type</code> parameter to <code>handle_new_pr_opened</code> and <br><code>get_log_context</code> functions to identify the sender type.<br> <li> Implemented a check to ignore PRs opened by bots based on the new <br><code>ignore_bot_pr</code> setting in the configuration.<br> <li> Updated function calls to include the <code>sender_type</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/800/files#diff-3fb3f174152732d1b69953c8bd81b8a0a30f0e42100dc626d932da8371851608">+11/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Configuration Option to Ignore Bot-Opened PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/settings/configuration.toml

<li>Introduced a new configuration option <code>ignore_bot_pr</code> to enable ignoring <br>PRs opened by bots.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/800/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

