### PR TITLE
Small update to docs

### DIFF
--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -49,7 +49,7 @@ To edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agen
 
     - `enable_semantic_files_types`: if set to true, "Changes walkthrough" section will be generated. Default is true.
     - `collapsible_file_list`: if set to true, the file list in the "Changes walkthrough" section will be collapsible. If set to "adaptive", the file list will be collapsible only if there are more than 8 files. Default is "adaptive".
-    - `enable_help_text`: if set to true, the tool will display a help text in the comment. Default is true.
+    - `enable_help_text`: if set to true, the tool will display a help text in the comment. Default is false.
 
 ### Inline file summary 💎
 

--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -49,7 +49,8 @@ To edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agen
 
     - `enable_semantic_files_types`: if set to true, "Changes walkthrough" section will be generated. Default is true.
     - `collapsible_file_list`: if set to true, the file list in the "Changes walkthrough" section will be collapsible. If set to "adaptive", the file list will be collapsible only if there are more than 8 files. Default is "adaptive".
-  
+    - `enable_help_text`: if set to true, the tool will display a help text in the comment. Default is true.
+
 ### Inline file summary 💎
 
 This feature enables you to copy the `changes walkthrough` table to the "Files changed" tab, so you can quickly understand the changes in each file while reviewing the code changes (diff view).

--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -33,6 +33,7 @@ To edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agen
     - `inline_code_comments`: if set to true, the tool will publish the code suggestions as comments on the code diff. Default is false.
     - `persistent_comment`: if set to true, the review comment will be persistent, meaning that every new review request will edit the previous one. Default is true.
     - `extra_instructions`: Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".
+    - `enable_help_text`: if set to true, the tool will display a help text in the comment. Default is true.
 
 !!! example "Enable\\disable sub-sections"
     You can enable or disable specific sub-sections of the review tool:


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- Introduced documentation for a new configuration option `enable_help_text` across two documentation files.
- In `describe.md`, explained how `enable_help_text` can be used to display help text in comments, with a default value of false.
- In `review.md`, detailed the use of `enable_help_text` for displaying help text in review comments, with a default value of true.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>describe.md</strong><dd><code>Documentation for New `enable_help_text` Configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/docs/tools/describe.md

<li>Added documentation for <code>enable_help_text</code> configuration, explaining its <br>purpose and default value.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/810/files#diff-960aad71fec9617804a02c904da37db217b6ba8a48fec3ac8bda286511d534eb">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>review.md</strong><dd><code>Enhance Review Tool Documentation with `enable_help_text`</code></dd></summary>
<hr>
      
docs/docs/tools/review.md

<li>Introduced <code>enable_help_text</code> configuration with a default value of <br>true, enhancing the review tool documentation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/810/files#diff-8e6363749b8b0a82468e5fbb0796cee806dc48e70e7472b04088d56d2c415094">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

