### PR TITLE
chore: fix some typos

### DIFF
--- a/docs/docs/installation/azure.md
+++ b/docs/docs/installation/azure.md
@@ -7,12 +7,12 @@ git_provider="azure"
 ```
 
 Azure DevOps provider supports [PAT token](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows) or [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication-overview#authentication-in-server-environments) authentication.
-PAT is faster to create, but has build in experation date, and will use the user identity for API calls. 
-Using DefaultAzureCredential you can use managed identity or Service principle, which are more secure and will create seperate ADO user identity (via AAD) to the agent.
+PAT is faster to create, but has build in expiration date, and will use the user identity for API calls. 
+Using DefaultAzureCredential you can use managed identity or Service principle, which are more secure and will create separate ADO user identity (via AAD) to the agent.
 
-If PAT was choosen, you can assign the value in .secrets.toml. 
-If DefaultAzureCredential was choosen, you can assigned the additional env vars like AZURE_CLIENT_SECRET directly, 
-or use managed identity/az cli (for local develpment) without any additional configuration.
+If PAT was chosen, you can assign the value in .secrets.toml. 
+If DefaultAzureCredential was chosen, you can assigned the additional env vars like AZURE_CLIENT_SECRET directly, 
+or use managed identity/az cli (for local development) without any additional configuration.
 in any case, 'org' value must be assigned in .secrets.toml:
 ```
 [azure_devops]

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -173,12 +173,12 @@ git_provider="azure"
 ```
 
 Azure DevOps provider supports [PAT token](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows) or [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication-overview#authentication-in-server-environments) authentication.
-PAT is faster to create, but has build in experation date, and will use the user identity for API calls. 
-Using DefaultAzureCredential you can use managed identity or Service principle, which are more secure and will create seperate ADO user identity (via AAD) to the agent.
+PAT is faster to create, but has build in expiration date, and will use the user identity for API calls. 
+Using DefaultAzureCredential you can use managed identity or Service principle, which are more secure and will create separate ADO user identity (via AAD) to the agent.
 
-If PAT was choosen, you can assign the value in .secrets.toml. 
-If DefaultAzureCredential was choosen, you can assigned the additional env vars like AZURE_CLIENT_SECRET directly, 
-or use managed identity/az cli (for local develpment) without any additional configuration.
+If PAT was chosen, you can assign the value in .secrets.toml. 
+If DefaultAzureCredential was chosen, you can assigned the additional env vars like AZURE_CLIENT_SECRET directly, 
+or use managed identity/az cli (for local development) without any additional configuration.
 in any case, 'org' value must be assigned in .secrets.toml:
 ```
 [azure_devops]


### PR DESCRIPTION
## **Type**
Documentation


___

## **Description**
- Corrected spelling errors and improved clarity in the Azure DevOps provider authentication sections across two documentation files.
- Specifically, fixed typos related to "expiration", "separate", "chosen", and "development" in both `azure.md` and `automations_and_usage.md`.
- Made the documentation more readable and easier to understand for users setting up Azure DevOps authentication.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azure.md</strong><dd><code>Fix Typos in Azure DevOps Authentication Documentation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/docs/installation/azure.md

<li>Corrected spelling mistakes in the Azure DevOps provider <br>authentication section.<br> <li> Improved clarity by fixing typos related to the use of PAT and <br>DefaultAzureCredential.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/811/files#diff-8b88870a27016c805466301c6a2fac12c560147538f7bec211eb479b05c46b53">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>automations_and_usage.md</strong><dd><code>Correct Spelling and Improve Clarity in Azure DevOps Documentation</code></dd></summary>
<hr>
      
docs/docs/usage-guide/automations_and_usage.md

<li>Corrected spelling mistakes in the Azure DevOps provider <br>authentication section.<br> <li> Enhanced readability by fixing typos regarding PAT and <br>DefaultAzureCredential usage.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/811/files#diff-878bb0ecba4567cf6a5fa750521c6822078e4da41864153ab50a2e236e8e9451">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

