### PR TITLE
ignore bot

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -118,15 +118,9 @@ async def handle_new_pr_opened(body: Dict[str, Any],
                                event: str,
                                sender: str,
                                sender_id: str,
-                               sender_type: str,
                                action: str,
                                log_context: Dict[str, Any],
                                agent: PRAgent):
-    # logic to ignore PRs opened by bot
-    if get_settings().get("GITHUB_APP.IGNORE_BOT_PR", False) and sender_type == "Bot":
-        get_logger().info(f"Ignoring PR from '{sender=}' due to github_app.ignore_bot_pr setting")
-        return {}
-
     title = body.get("pull_request", {}).get("title", "")
 
     # logic to ignore PRs with specific titles (e.g. "[Auto] ...")
@@ -261,6 +255,11 @@ async def handle_request(body: Dict[str, Any], event: str):
     agent = PRAgent()
     log_context, sender, sender_id, sender_type = get_log_context(body, event, action, build_number)
 
+    # logic to ignore PRs opened by bot
+    if get_settings().get("GITHUB_APP.IGNORE_BOT_PR", False) and sender_type == "Bot":
+        get_logger().info(f"Ignoring PR from '{sender=}' due to github_app.ignore_bot_pr setting")
+        return {}
+
     # handle comments on PRs
     if action == 'created':
         get_logger().debug(f'Request body', artifact=body, event=event)
@@ -268,7 +267,7 @@ async def handle_request(body: Dict[str, Any], event: str):
     # handle new PRs
     elif event == 'pull_request' and action != 'synchronize' and action != 'closed':
         get_logger().debug(f'Request body', artifact=body, event=event)
-        await handle_new_pr_opened(body, event, sender, sender_id, sender_type, action, log_context, agent)
+        await handle_new_pr_opened(body, event, sender, sender_id, action, log_context, agent)
     # handle pull_request event with synchronize action - "push trigger" for new commits
     elif event == 'pull_request' and action == 'synchronize':
         get_logger().debug(f'Request body', artifact=body, event=event)


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Centralized the logic to ignore PRs opened by bots into the `handle_request` function for better code organization and readability.
- Removed the `sender_type` parameter from the `handle_new_pr_opened` function as part of the refactor.
- Added explanatory comments to make the bot ignore logic clearer and more maintainable.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_app.py</strong><dd><code>Centralize Bot PR Ignore Logic and Refactor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/servers/github_app.py

<li>Refactored bot PR ignore logic to a more centralized location.<br> <li> Removed sender_type parameter from handle_new_pr_opened function.<br> <li> Added comments for clarity on bot ignore logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/817/files#diff-3fb3f174152732d1b69953c8bd81b8a0a30f0e42100dc626d932da8371851608">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

