### PR TITLE
Fix publish_output_progress when comment is not temporary

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -229,7 +229,7 @@ class GithubProvider(GitProvider):
         self.publish_comment(pr_comment)
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
-        if is_temporary and not get_settings().config.publish_output_progress:
+        if is_temporary or not get_settings().config.publish_output_progress:
             get_logger().debug(f"Skipping publish_comment for temporary comment: {pr_comment}")
             return
 


### PR DESCRIPTION
## **User description**
Bug Description:
When people are setting the `publish_output_progress` to true but they are still getting emails with progress comment.

![image](https://github.com/Codium-ai/pr-agent/assets/1441832/7cf3d290-2a52-423f-aa77-e5c9bded6067)


___

## **Type**
bug_fix


___

## **Description**
- Fixed an issue where progress comments were incorrectly published even when `publish_output_progress` was set to false.
- This change ensures that temporary comments or when the setting is disabled, comments are not published, aligning with expected behavior.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_provider.py</strong><dd><code>Fix Comment Publishing Logic in GitHub Provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/git_providers/github_provider.py

<li>Changed logical condition from <code>and</code> to <code>or</code> to correctly skip publishing <br>comments when <code>publish_output_progress</code> is false or the comment is <br>temporary.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/830/files#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

