### PR TITLE
feat: add persistent comment option for PR descriptions

### DIFF
--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -27,6 +27,8 @@ To edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agen
 
     - `publish_description_as_comment`: if set to true, the tool will publish the description as a comment to the PR. If false, it will overwrite the original description. Default is false.
 
+    - `publish_description_as_comment_persistent`: if set to true and `publish_description_as_comment` is true, the tool will publish the description as a persistent comment to the PR. Default is true.
+
     - `add_original_user_description`: if set to true, the tool will add the original user description to the generated description. Default is true.
 
     - `keep_original_user_title`: if set to true, the tool will keep the original PR title, and won't change it. Default is true.

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -52,7 +52,6 @@ maximal_review_effort=5
 
 [pr_description] # /describe #
 publish_labels=true
-publish_description_as_comment=false
 add_original_user_description=true
 keep_original_user_title=true
 use_bullet_points=true
@@ -61,6 +60,9 @@ enable_pr_type=true
 final_update_message = true
 enable_help_text=false
 enable_help_comment=true
+# describe as comment
+publish_description_as_comment=false
+publish_description_as_comment_persistent=true
 ## changes walkthrough section
 enable_semantic_files_types=true
 collapsible_file_list='adaptive' # true, false, 'adaptive'

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -132,7 +132,14 @@ class PRDescription:
                 # publish description
                 if get_settings().pr_description.publish_description_as_comment:
                     full_markdown_description = f"## Title\n\n{pr_title}\n\n___\n{pr_body}"
-                    self.git_provider.publish_comment(full_markdown_description)
+                    if get_settings().pr_description.publish_description_as_comment_persistent:
+                        self.git_provider.publish_persistent_comment(full_markdown_description,
+                                                                     initial_header="## Title",
+                                                                     update_header=True,
+                                                                     name="describe",
+                                                                     final_update_message=False, )
+                    else:
+                        self.git_provider.publish_comment(full_markdown_description)
                 else:
                     self.git_provider.publish_description(pr_title, pr_body)
 


### PR DESCRIPTION
## **User description**
[pr_description] # /describe #
publish_description_as_comment=false
publish_description_as_comment_persistent=true

<img width="944" alt="image" src="https://github.com/Codium-ai/pr-agent/assets/21198860/e7f6c799-7eb9-4837-b85b-b93acdb9e512">


___

## **Type**
enhancement


___

## **Description**
- Introduced the ability to publish PR descriptions as persistent comments, enhancing the flexibility and control over how PR descriptions are displayed.
- Added new settings in `configuration.toml` to control the publication of PR descriptions as either regular or persistent comments.
- This change allows for better management of PR descriptions, especially in scenarios where updates to the PR description are frequent.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description.py</strong><dd><code>Support for Persistent Comments in PR Descriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/tools/pr_description.py

<li>Added support for publishing persistent comments in PR descriptions.<br> <li> Persistent comments are enabled with a specific setting.<br> <li> Regular comments are published if persistent comments are not enabled.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/837/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Configuration Changes for Persistent PR Description Comments</code></dd></summary>
<hr>
      
pr_agent/settings/configuration.toml

<li>Introduced settings for controlling the publication of PR descriptions <br>as persistent comments.<br> <li> Removed the previous setting for publishing descriptions as comments, <br>integrating it with the new persistent option.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/837/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

