### PR TITLE
Handle OPENAI_KEY not set error in github_action_runner.py

### DIFF
--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -46,15 +46,16 @@ async def run_action():
     if not GITHUB_EVENT_PATH:
         print("GITHUB_EVENT_PATH not set")
         return
-    if not OPENAI_KEY:
-        print("OPENAI_KEY not set")
-        return
     if not GITHUB_TOKEN:
         print("GITHUB_TOKEN not set")
         return
 
     # Set the environment variables in the settings
-    get_settings().set("OPENAI.KEY", OPENAI_KEY)
+    if OPENAI_KEY:
+        get_settings().set("OPENAI.KEY", OPENAI_KEY)
+    else:
+        # Might not be set if the user is using models not from OpenAI
+        print("OPENAI_KEY not set")
     if OPENAI_ORG:
         get_settings().set("OPENAI.ORG", OPENAI_ORG)
     get_settings().set("GITHUB.USER_TOKEN", GITHUB_TOKEN)


### PR DESCRIPTION
## **User description**
Fixes https://github.com/Codium-ai/pr-agent/issues/855


___

## **Type**
bug_fix


___

## **Description**
- Improved error handling for the `OPENAI_KEY` environment variable in `github_action_runner.py` to allow the GitHub Action runner to proceed even if the `OPENAI_KEY` is not set. This change accommodates scenarios where users might be using models not provided by OpenAI.
- Added informative logging to notify users when the `OPENAI_KEY` is not set, enhancing the user experience by clarifying the non-critical nature of this environment variable for certain use cases.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_action_runner.py</strong><dd><code>Improved Handling of Missing `OPENAI_KEY` Environment Variable</code></dd></summary>
<hr>
      
pr_agent/servers/github_action_runner.py

<li>Modified the handling of the <code>OPENAI_KEY</code> environment variable to allow <br>the GitHub Action runner to proceed without it being set.<br> <li> Added a conditional check to set <code>OPENAI.KEY</code> only if <code>OPENAI_KEY</code> is <br>present.<br> <li> Added a message to inform the user when <code>OPENAI_KEY</code> is not set, <br>indicating the possibility of using models not from OpenAI.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/858/files#diff-15f9c11da031449998128bdbba057d768853e836eedf44563be71b3847be80e0">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

