### PR TITLE
Add repo url to docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: PR-Agent Documentation 
-description: Documentation for PR-Agent, the AI-powered Pull Request tool.
 repo_url: https://github.com/Codium-ai/pr-agent
 repo_name: Codium-ai/pr-agent
+
 nav: 
   - Overview: 'index.md'
   - Installation: 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: PR-Agent Documentation 
 description: Documentation for PR-Agent, the AI-powered Pull Request tool.
 repo_url: https://github.com/Codium-ai/pr-agent
-
+repo_name: Codium-ai/pr-agent
 nav: 
   - Overview: 'index.md'
   - Installation: 
@@ -41,6 +41,8 @@ theme:
   logo: assets/logo.svg
   favicon: assets/favicon.ico
   name: material
+  icon:
+    repo: fontawesome/brands/github
   features:
     - navigation.tabs
     - navigation.expand

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: PR-Agent
+repo_url: https://github.com/Codium-ai/pr-agent
 
 nav: 
   - Overview: 'index.md'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,5 @@
-site_name: PR-Agent
+site_name: PR-Agent Documentation 
+description: Documentation for PR-Agent, the AI-powered Pull Request tool.
 repo_url: https://github.com/Codium-ai/pr-agent
 
 nav: 


### PR DESCRIPTION
Adding a repo URL adds a nice link to the PR-Agent repo, with # of stars and more

## **Type**
documentation, enhancement


___

## **Description**
- Renamed the MkDocs site to "PR-Agent Documentation" for better clarity.
- Added a description for the site to improve SEO and user understanding.
- Included the GitHub repository URL to make the source code easily accessible.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mkdocs.yml</strong><dd><code>Enhance MkDocs Configuration with Site Description and Repo URL</code></dd></summary>
<hr>
      
docs/mkdocs.yml

<li>Renamed site to "PR-Agent Documentation".<br> <li> Added a site description.<br> <li> Included the GitHub repository URL.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/863/files#diff-7618337a88ea47f9b778a21f0e17d43eab2aba4880c6be2d95a7bf95e4b8b2df">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

