### PR TITLE
docs: Add option to disable automatic CI feedback in configuration

### DIFF
--- a/docs/docs/tools/ci_feedback.md
+++ b/docs/docs/tools/ci_feedback.md
@@ -23,6 +23,14 @@ In addition to being automatically triggered, the tool can also be invoked manua
 ```
 where `{repo_name}` is the name of the repository, `{run_number}` is the run number of the failed check, and `{job_number}` is the job number of the failed check.
 
+## Disabling the tool from running automatically
+
+If you wish to disable the tool from running automatically, you can do so by adding the following configuration to the configuration file:
+```
+[checks]
+enable_auto_checks_feedback = false
+```
+
 ## Configuration options
 - `enable_auto_checks_feedback` - if set to true, the tool will automatically provide feedback when a check is failed. Default is true.
 - `excluded_checks_list` - a list of checks to exclude from the feedback, for example: ["check1", "check2"]. Default is an empty list.


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- Added documentation on how to disable the automatic CI feedback tool by modifying the configuration file.
- Included a configuration example where `enable_auto_checks_feedback` is set to false to prevent automatic feedback.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci_feedback.md</strong><dd><code>Add Documentation for Disabling Automatic CI Feedback</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/docs/tools/ci_feedback.md

<li>Added a new section on how to disable automatic CI feedback.<br> <li> Provided a configuration snippet to disable automatic feedback.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/873/files#diff-97373ef777514b2c1e4e50afff9bb7dc1dafe1d0b4a7d38f4290de39323cd0d9">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

