### PR TITLE
Fix duplicate assignment of replicate_key in LiteLLMAIHandler

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -54,8 +54,6 @@ class LiteLLMAIHandler(BaseAiHandler):
             litellm.cohere_key = get_settings().cohere.key
         if get_settings().get("REPLICATE.KEY", None):
             litellm.replicate_key = get_settings().replicate.key
-        if get_settings().get("REPLICATE.KEY", None):
-            litellm.replicate_key = get_settings().replicate.key
         if get_settings().get("HUGGINGFACE.KEY", None):
             litellm.huggingface_key = get_settings().huggingface.key
         if get_settings().get("HUGGINGFACE.API_BASE", None) and 'huggingface' in get_settings().config.model:


### PR DESCRIPTION
## **User description**
- Fix duplicate assignment of replicate_key in LiteLLMAIHandler


___

## **Type**
Bug fix


___

## **Description**
- Removed a redundant line that assigned `replicate_key` twice in `LiteLLMAIHandler`'s constructor.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm_ai_handler.py</strong><dd><code>Remove duplicate assignment of replicate_key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/algo/ai_handlers/litellm_ai_handler.py

<li>Removed duplicate assignment of <code>replicate_key</code> to prevent redundant <br>operations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/876/files#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfe">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

