### PR TITLE
Fixed error logging in Azure DevOps provider

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -303,12 +303,18 @@ class AzureDevopsProvider(GitProvider):
                     )
                     original_file_content_str = original_file_content_str.content
                 except Exception as error:
-                    get_logger().error(
-                        "Failed to retrieve original file content of %s at version %s. Error: %s" %
-                        (file,
-                        version,
-                        str(error)),
-                    )
+                    if not head_sha:
+                        get_logger().error(
+                            "Failed to retrieve original file content of %s at version %s. Error: %s" %
+                            (file,
+                            version,
+                            str(error)),
+                        )
+                    else:
+                        get_logger().warning(
+                            "Unable to locate previous versions for file %s. Maybe it has been added in this PR" %
+                            (file)
+                        )
                     original_file_content_str = ""
 
                 patch = load_large_diff(

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -274,10 +274,10 @@ class AzureDevopsProvider(GitProvider):
                     new_file_content_str = new_file_content_str.content
                 except Exception as error:
                     get_logger().error(
-                        "Failed to retrieve new file content of %s at version %s. Error: %s",
-                        file,
+                        "Failed to retrieve new file content of %s at version %s. Error: %s" %
+                        (file,
                         version,
-                        str(error),
+                        str(error)),
                     )
                     new_file_content_str = ""
 
@@ -304,10 +304,10 @@ class AzureDevopsProvider(GitProvider):
                     original_file_content_str = original_file_content_str.content
                 except Exception as error:
                     get_logger().error(
-                        "Failed to retrieve original file content of %s at version %s. Error: %s",
-                        file,
+                        "Failed to retrieve original file content of %s at version %s. Error: %s" %
+                        (file,
                         version,
-                        str(error),
+                        str(error)),
                     )
                     original_file_content_str = ""
 


### PR DESCRIPTION
### **User description**
Fixed a bug that caused "%s" to be logged when errors occurred during file diffs using in Azure DevOps provider


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect string formatting in error logging within the Azure DevOps provider. This change ensures that the file name and version are properly displayed in the log when an error occurs during file content retrieval.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Fix Error Logging String Formatting in Azure DevOps Provider</code></dd></summary>
<hr>
      
pr_agent/git_providers/azuredevops_provider.py

<li>Corrected the string formatting in error logging for both new and <br>original file content retrieval failures.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/900/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

