### PR TITLE
Update default setting of `final_update_message` to false in describe…

### DIFF
--- a/docs/docs/tools/describe.md
+++ b/docs/docs/tools/describe.md
@@ -77,7 +77,7 @@ publish_labels = ...
   </tr>
   <tr>
     <td><b>final_update_message</b></td>
-    <td>If set to true, it will add a comment message [`PR Description updated to latest commit...`](https://github.com/Codium-ai/pr-agent/pull/499#issuecomment-1837412176) after finishing calling `/describe`. Default is true.</td>
+    <td>If set to true, it will add a comment message [`PR Description updated to latest commit...`](https://github.com/Codium-ai/pr-agent/pull/499#issuecomment-1837412176) after finishing calling `/describe`. Default is false.</td>
   </tr>
   <tr>
     <td><b>enable_semantic_files_types</b></td>

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -58,7 +58,7 @@ generate_ai_title=false
 use_bullet_points=true
 extra_instructions = ""
 enable_pr_type=true
-final_update_message = true
+final_update_message = false
 enable_help_text=false
 enable_help_comment=true
 # describe as comment


### PR DESCRIPTION
### **User description**
….md and configuration.toml


___

### **PR Type**
documentation, configuration changes


___

### **Description**
- Updated the default setting of `final_update_message` to false in the `describe.md` documentation file.
- Changed the default value of `final_update_message` to false in the `configuration.toml` file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>describe.md</strong><dd><code>Update default setting of `final_update_message` in documentation</code></dd></summary>
<hr>
      
docs/docs/tools/describe.md

<li>Updated the default setting of <code>final_update_message</code> to false in the <br>documentation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/913/files#diff-960aad71fec9617804a02c904da37db217b6ba8a48fec3ac8bda286511d534eb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Change default value of `final_update_message` in configuration</code></dd></summary>
<hr>
      
pr_agent/settings/configuration.toml

<li>Changed the default value of <code>final_update_message</code> to false in the <br>configuration file.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/913/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

