### PR TITLE
Bitbucket Server Provider Fixes

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -1,13 +1,13 @@
 import json
 from typing import Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import quote_plus, urlparse
 
 import requests
 from atlassian.bitbucket import Bitbucket
 from starlette_context import context
 
 from .git_provider import GitProvider
-from pr_agent.algo.types import FilePatchInfo
+from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 from ..algo.utils import load_large_diff, find_line_number_of_relevant_line_in_file
 from ..config_loader import get_settings
 from ..log import get_logger
@@ -58,6 +58,9 @@ class BitbucketServerProvider(GitProvider):
             return contents
         except Exception:
             return ""
+        
+    def get_pr_id(self):
+        return self.pr_num
 
     def publish_code_suggestions(self, code_suggestions: list) -> bool:
         """
@@ -140,14 +143,8 @@ class BitbucketServerProvider(GitProvider):
         if self.diff_files:
             return self.diff_files
 
-        commits_in_pr = self.bitbucket_client.get_pull_requests_commits(
-            self.workspace_slug,
-            self.repo_slug,
-            self.pr_num
-        )
-
-        commit_list = list(commits_in_pr)
-        base_sha, head_sha = commit_list[0]['parents'][0]['id'], commit_list[-1]['id']
+        base_sha = self.pr.toRef['latestCommit']
+        head_sha = self.pr.fromRef['latestCommit']
 
         diff_files = []
         original_file_content_str = ""
@@ -242,7 +239,7 @@ class BitbucketServerProvider(GitProvider):
         }
 
         response = requests.post(url=self._get_pr_comments_url(), json=payload, headers=self.headers)
-        return response
+        response.raise_for_status()
 
     def generate_link_to_relevant_line_number(self, suggestion) -> str:
         try:
@@ -256,7 +253,7 @@ class BitbucketServerProvider(GitProvider):
                 (diff_files, relevant_file, relevant_line_str)
 
             if absolute_position != -1 and self.pr_url:
-                link = f"{self.pr_url}/#L{relevant_file}T{absolute_position}"
+                link = f"{self.pr_url}/diff#{quote_plus(relevant_file)}?t={absolute_position}"
                 return link
         except Exception as e:
             if get_settings().config.verbosity_level >= 2:
@@ -266,7 +263,15 @@ class BitbucketServerProvider(GitProvider):
 
     def publish_inline_comments(self, comments: list[dict]):
         for comment in comments:
-            self.publish_inline_comment(comment['body'], comment['position'], comment['path'])
+            if 'position' in comment:
+                self.publish_inline_comment(comment['body'], comment['position'], comment['path'])
+            elif 'start_line' in comment: # multi-line comment
+                # note that bitbucket does not seem to support range - only a comment on a single line - https://community.developer.atlassian.com/t/api-post-endpoint-for-inline-pull-request-comments/60452
+                self.publish_inline_comment(comment['body'], comment['start_line'], comment['path'])
+            elif 'line' in comment: # single-line comment
+                self.publish_inline_comment(comment['body'], comment['line'], comment['path'])
+            else:
+                get_logger().error(f"Could not publish inline comment {comment}")
 
     def get_title(self):
         return self.pr.title
@@ -278,7 +283,10 @@ class BitbucketServerProvider(GitProvider):
         return self.pr.fromRef['displayId']
 
     def get_pr_description_full(self):
-        return self.pr.description
+        if hasattr(self.pr, "description"):
+            return self.pr.description
+        else:
+            return None
 
     def get_user_id(self):
         return 0
@@ -334,13 +342,14 @@ class BitbucketServerProvider(GitProvider):
             raise NotImplementedError("Get commit messages function not implemented yet.")
     # bitbucket does not support labels
     def publish_description(self, pr_title: str, description: str):
-        payload = json.dumps({
+        payload = {
+            "version": self.pr.version,
             "description": description,
-            "title": pr_title
-        })
-
-        response = requests.put(url=self.bitbucket_pull_request_api_url, headers=self.headers, data=payload)
-        return response
+            "title": pr_title,
+            "reviewers": self.pr.reviewers # needs to be sent otherwise gets wiped
+        }
+        
+        self.bitbucket_client.update_pull_request(self.workspace_slug, self.repo_slug, str(self.pr_num), payload)
 
     # bitbucket does not support labels
     def publish_labels(self, pr_types: list):


### PR DESCRIPTION
### **User description**
Seems this code hasn't been maintained. Contains the following fixes to minimally get it up and running:

* Fix missing import
* Fix missing attribute error when PR description is empty
* Fix diff using incorrect to/from
* Fix PR id retrieval
* Fix some errors not being propagated
* Fix description publishing not using correct url

Tested with BB Datacenter ("server" rebranded) v8.9.9


___

### **PR Type**
Bug fix


___

### **Description**
This PR includes several bug fixes and improvements for the Bitbucket Server provider:
- Added missing import for `quote_plus`.
- Introduced `get_pr_id` method to retrieve PR ID.
- Corrected base and head SHA retrieval for diffs.
- Ensured errors are raised for failed inline comment publishing.
- Fixed URL generation for relevant line links.
- Improved handling of inline comments, including multi-line and single-line comments.
- Added check for PR description attribute existence.
- Updated `publish_description` to use Bitbucket client and include reviewers.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_server_provider.py</strong><dd><code>Multiple bug fixes and improvements for Bitbucket Server provider.</code></dd></summary>
<hr>
      
pr_agent/git_providers/bitbucket_server_provider.py

<li>Added missing import for <code>quote_plus</code>.<br> <li> Introduced <code>get_pr_id</code> method to retrieve PR ID.<br> <li> Corrected base and head SHA retrieval for diffs.<br> <li> Ensured errors are raised for failed inline comment publishing.<br> <li> Fixed URL generation for relevant line links.<br> <li> Improved handling of inline comments, including multi-line and <br>single-line comments.<br> <li> Added check for PR description attribute existence.<br> <li> Updated <code>publish_description</code> to use Bitbucket client and include <br>reviewers.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/928/files#diff-c9ca96d14ab7a2935714944f8f377c4a9bb425efde19e66595bb58d33e9f5a40">+29/-20</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

