### PR TITLE
Add logging for skipping non-code files in GitHub provider

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -147,6 +147,7 @@ class GithubProvider(GitProvider):
 
             for file in files:
                 if not is_valid_file(file.filename):
+                    get_logger().info(f"Skipping a non-code file: {file.filename}")
                     continue
 
                 new_file_content_str = self._get_pr_file_content(file, self.pr.head.sha)  # communication with GitHub


### PR DESCRIPTION
### **PR Type**
enhancement, logging


___

### **Description**
- Added logging to inform when non-code files are skipped in the GitHub provider.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_provider.py</strong><dd><code>Add logging for non-code file skips in GitHub provider</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/git_providers/github_provider.py

- Added logging for skipping non-code files in the GitHub provider.



</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/931/files#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

