### PR TITLE
Bitbucket server filter out globally ignored files before attempting diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea/
+.lsp/
+.vscode/
 venv/
 pr_agent/settings/.secrets.toml
 __pycache__

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -8,6 +8,7 @@ from starlette_context import context
 
 from .git_provider import GitProvider
 from pr_agent.algo.types import FilePatchInfo
+from ..algo.language_handler import is_valid_file
 from ..algo.utils import load_large_diff, find_line_number_of_relevant_line_in_file
 from ..config_loader import get_settings
 from ..log import get_logger
@@ -156,6 +157,10 @@ class BitbucketServerProvider(GitProvider):
         changes = self.bitbucket_client.get_pull_requests_changes(self.workspace_slug, self.repo_slug, self.pr_num)
         for change in changes:
             file_path = change['path']['toString']
+            if not is_valid_file(file_path.split("/")[-1]):
+                get_logger().info(f"Skipping a non-code file: {file_path}")
+                continue
+
             match change['type']:
                 case 'ADD':
                     edit_type = EDIT_TYPE.ADDED


### PR DESCRIPTION
### **User description**
Solves #931 for BB server


___

### **PR Type**
enhancement, logging


___

### **Description**
- Enhanced the Bitbucket Server provider to filter out globally ignored files before attempting to diff.
- Added logging to provide information about skipped non-code files.
- Improved the efficiency of the diff process by avoiding unnecessary operations on non-code files.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_server_provider.py</strong><dd><code>Filter out globally ignored files and add logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pr_agent/git_providers/bitbucket_server_provider.py

<li>Imported <code>is_valid_file</code> function to validate file types.<br> <li> Added a check to skip non-code files based on global ignore rules.<br> <li> Included logging to inform about skipped non-code files.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/932/files#diff-c9ca96d14ab7a2935714944f8f377c4a9bb425efde19e66595bb58d33e9f5a40">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

