### PR TITLE
Disable final update message when auto_describe is enabled in GitHub …

### DIFF
--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -118,7 +118,6 @@ Specifically, start by setting the following environment variables:
         github_action_config.auto_review: "true" # enable\disable auto review
         github_action_config.auto_describe: "true" # enable\disable auto describe
         github_action_config.auto_improve: "true" # enable\disable auto improve
-        github_action_config.enable_output: "true" # enable\disable github actions output parameter
 ```
 `github_action_config.auto_review`, `github_action_config.auto_describe` and `github_action_config.auto_improve` are used to enable/disable automatic tools that run when a new PR is opened.
 If not set, the default configuration is for all three tools to run automatically when a new PR is opened.

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -99,6 +99,7 @@ async def run_action():
 
                 # invoke by default all three tools
                 if auto_describe is None or is_true(auto_describe):
+                    get_settings().pr_description.final_update_message = False  # No final update message when auto_describe is enabled
                     await PRDescription(pr_url).run()
                 if auto_review is None or is_true(auto_review):
                     await PRReviewer(pr_url).run()


### PR DESCRIPTION
### **User description**
…Action Runner


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Disabled the final update message in the GitHub Action Runner when `auto_describe` is enabled by setting `final_update_message` to `False`.
- Updated the usage guide documentation to remove the `enable_output` configuration line.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_action_runner.py</strong><dd><code>Disable final update message for auto_describe in GitHub Action Runner</code></dd></summary>
<hr>
      
pr_agent/servers/github_action_runner.py

<li>Disabled final update message when <code>auto_describe</code> is enabled.<br> <li> Added a line to set <code>final_update_message</code> to <code>False</code> in settings.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/939/files#diff-15f9c11da031449998128bdbba057d768853e836eedf44563be71b3847be80e0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>automations_and_usage.md</strong><dd><code>Update usage guide to remove enable_output configuration</code>&nbsp; </dd></summary>
<hr>
      
docs/docs/usage-guide/automations_and_usage.md

- Removed documentation line for `enable_output` configuration.



</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/939/files#diff-878bb0ecba4567cf6a5fa750521c6822078e4da41864153ab50a2e236e8e9451">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

