### PR TITLE
gitlab push_commands

### DIFF
--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -136,7 +136,7 @@ publish_labels = false
 to prevent PR-Agent from publishing labels when running the `describe` tool.
 
 ## GitLab Webhook
-After setting up a GitLab webhook, to control which commands will run automatically when a new PR is opened, you can set the `pr_commands` parameter in the configuration file, similar to the GitHub App:
+After setting up a GitLab webhook, to control which commands will run automatically when a new MR is opened, you can set the `pr_commands` parameter in the configuration file, similar to the GitHub App:
 ```
 [gitlab]
 pr_commands = [
@@ -145,6 +145,20 @@ pr_commands = [
     "/improve",
 ]
 ```
+
+the GitLab webhook can also respond to new code that is pushed to an open MR.
+The configuration toggle `handle_push_trigger` can be used to enable this feature.  
+The configuration parameter `push_commands` defines the list of tools that will be **run automatically** when new code is pushed to the MR.
+```
+[gitlab]
+handle_push_trigger = true
+push_commands = [
+    "/describe",
+    "/review  --pr_reviewer.num_code_suggestions=0 --pr_reviewer.final_update_message=false",
+]
+```
+
+Note that to use the 'handle_push_trigger' feature, you need give the gitlab webhook also the "Push events" scope.
 
 ## BitBucket App
 Similar to GitHub app, when running PR-Agent from BitBucket App, the default [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) from a pre-built docker will be initially loaded.

--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -158,7 +158,7 @@ push_commands = [
 ]
 ```
 
-Note that to use the 'handle_push_trigger' feature, you need give the gitlab webhook also the "Push events" scope.
+Note that to use the 'handle_push_trigger' feature, you need to give the gitlab webhook also the "Push events" scope.
 
 ## BitBucket App
 Similar to GitHub app, when running PR-Agent from BitBucket App, the default [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) from a pre-built docker will be initially loaded.


### PR DESCRIPTION
### **PR Type**
documentation, enhancement


___

### **Description**
- Updated GitLab webhook documentation to use "MR" instead of "PR".
- Added new configuration options for handling push events in GitLab:
  - `handle_push_trigger` to enable the feature.
  - `push_commands` to define tools that run automatically on new code push.
- Included a note about the necessity of the "Push events" scope for the GitLab webhook.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>automations_and_usage.md</strong><dd><code>Update GitLab webhook documentation with push command configurations</code></dd></summary>
<hr>
      
docs/docs/usage-guide/automations_and_usage.md

<li>Updated terminology from "PR" to "MR" for GitLab.<br> <li> Added documentation for <code>handle_push_trigger</code> configuration.<br> <li> Added documentation for <code>push_commands</code> configuration.<br> <li> Included note on required "Push events" scope for GitLab webhook.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/947/files#diff-878bb0ecba4567cf6a5fa750521c6822078e4da41864153ab50a2e236e8e9451">+15/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

