### PR TITLE
fix: update prompt key from `suggestion_content` to `suggestion_summary` in code suggestions

### DIFF
--- a/pr_agent/settings/pr_code_suggestions_reflect_prompts.toml
+++ b/pr_agent/settings/pr_code_suggestions_reflect_prompts.toml
@@ -59,12 +59,13 @@ class PRCodeSuggestionsFeedback(BaseModel):
 Example output:
 ```yaml
 code_suggestions:
-- suggestion_content: |
+- suggestion_summary: |
     Use a more descriptive variable name here
   relevant_file: "src/file1.py"
   suggestion_score: 6
   why: |
     The variable name 't' is not descriptive enough
+- ...
 ```
 
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated the key from `suggestion_content` to `suggestion_summary` in the example YAML output within the `pr_code_suggestions_reflect_prompts.toml` file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_code_suggestions_reflect_prompts.toml</strong><dd><code>Update key from <code>suggestion_content</code> to <code>suggestion_summary</code> in example <br>YAML</code></dd></summary>
<hr>
      
pr_agent/settings/pr_code_suggestions_reflect_prompts.toml

<li>Updated the key from <code>suggestion_content</code> to <code>suggestion_summary</code> in the <br>example YAML output.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/995/files#diff-aeee2207a4afb3ea3368c3e0140629bb3da8858b6d2315db5778661c9390d144">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

