### PR TITLE
Fix data type for `pr_files` field in PR description prompts

### DIFF
--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -48,7 +48,7 @@ class FileDescription(BaseModel):
 class PRDescription(BaseModel):
     type: List[PRType] = Field(description="one or more types that describe the PR content. Return the label member value (e.g. 'Bug fix', not 'bug_fix')")
 {%- if enable_semantic_files_types %}
-    pr_files: [List[FileDescription]] = Field(max_items=15, description="a list of the files in the PR, and their changes summary.")
+    pr_files: List[FileDescription] = Field(max_items=15, description="a list of the files in the PR, and their changes summary.")
 {%- endif %}
     description: str = Field(description="an informative and concise description of the PR. Use bullet points. Display first the most significant changes.")
     title: str = Field(description="an informative title for the PR, describing its main theme")


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the data type of the `pr_files` field in `pr_description_prompts.toml` from `[List[FileDescription]]` to `List[FileDescription]`


___



### **Changes walkthrough** 
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description_prompts.toml</strong><dd><code>Corrected data type for <code>pr_files</code> field in PR description prompt <br>settings</code></dd></summary>
<hr>

pr_agent/settings/pr_description_prompts.toml

<li>Fixed the data type of the <code>pr_files</code> field from <code>[List[FileDescription]]</code> <br>to <code>List[FileDescription]</code><br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1041/files#diff-a52546bc2f8a156d8ee786c403e44b1561a6e3f1d98fcfbe8a0120bcee59981b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>