### PR TITLE
fix broken output format(yaml) prompt

### DIFF
--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -165,7 +165,7 @@ review:
 {%- endif %}
 
 {%- if num_code_suggestions > 0 %}
-code_feedback
+code_feedback:
 - relevant_file: |
     directory/xxx.py
   language: |


### PR DESCRIPTION
### **User description**
Since the code_feedback field is a property of the YAML output, a colon (:) should follow it. Some LLM models might omit the colon, causing a parsing error.

+ Another suggestion
I observed sometimes that text output in relevant_line property has broken indentation. I think adding multiple line example with indentation could better indent output. 
```yaml
  relevant_line: |
    xxx
    xxx # added
```


___

### **PR Type**
bug fix, enhancement


___

### **Description**
- Fixed missing colon after `code_feedback` field to correct YAML format in `pr_agent/settings/pr_reviewer_prompts.toml`.
- Improved indentation for `relevant_line` property to ensure proper formatting.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer_prompts.toml</strong><dd><code>Fix YAML output format and improve indentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/pr_reviewer_prompts.toml

<li>Fixed missing colon after <code>code_feedback</code> field to correct YAML format.<br> <li> Improved indentation for <code>relevant_line</code> property to ensure proper <br>formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1048/files#diff-2e1ca45d2d8635b5f9cde801d9d210f6516e7f15d45dd9b0be134ac91e7a2e63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

