### PR TITLE
Fix deployment of GitHub app to GCP Cloud Run.

### DIFF
--- a/pr_agent/servers/gunicorn_config.py
+++ b/pr_agent/servers/gunicorn_config.py
@@ -24,7 +24,7 @@ import os
 #
 
 # bind = '0.0.0.0:5000'
-bind = '0.0.0.0:3000'
+bind = f'0.0.0.0:{os.environ.get("PORT", "3000")}'
 backlog = 2048
 
 #


### PR DESCRIPTION
### **User description**
I have followed [the official docs regarding cloud deployment of the GitHub app](https://pr-agent-docs.codium.ai/installation/github/#run-as-a-github-app), and have run into multiple issues. Most of these are docs-related (the secrets need to be passed as environment variables, not inside the secrets file, as per proper DevSecOps practice).

However if the service does not respect the `PORT` environment variable, deployment fails. This PR fixes that. It is in draft for now to possibly address the documentation problems as well.


___

### **PR Type**
Bug fix


___

### **Description**
- Updated Gunicorn configuration to respect the `PORT` environment variable for binding.
- Default to port 3000 if the `PORT` environment variable is not set.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gunicorn_config.py</strong><dd><code>Use `PORT` environment variable for binding in Gunicorn config</code></dd></summary>
<hr>

pr_agent/servers/gunicorn_config.py

<li>Changed the <code>bind</code> variable to use the <code>PORT</code> environment variable if <br>available.<br> <li> Default to port 3000 if <code>PORT</code> is not set.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1049/files#diff-aa57135d532088b55c798696d920373167b854afceac1f809b15847a5c8b5934">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

