### PR TITLE
Add support for gpt-4o-mini and gpt-4o-mini-2024-07-18 models

### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -17,6 +17,7 @@ MAX_TOKENS = {
     'gpt-4-turbo-2024-04-09': 128000,  # 128K, but may be limited by config.max_model_tokens
     'gpt-4-turbo': 128000,  # 128K, but may be limited by config.max_model_tokens
     'gpt-4o-mini': 128000,  # 128K, but may be limited by config.max_model_tokens
+    'gpt-4o-mini-2024-07-18': 128000,  # 128K, but may be limited by config.max_model_tokens
     'claude-instant-1': 100000,
     'claude-2': 100000,
     'command-nightly': 4096,

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -16,6 +16,7 @@ MAX_TOKENS = {
     'gpt-4-turbo-preview': 128000,  # 128K, but may be limited by config.max_model_tokens
     'gpt-4-turbo-2024-04-09': 128000,  # 128K, but may be limited by config.max_model_tokens
     'gpt-4-turbo': 128000,  # 128K, but may be limited by config.max_model_tokens
+    'gpt-4o-mini': 128000,  # 128K, but may be limited by config.max_model_tokens
     'claude-instant-1': 100000,
     'claude-2': 100000,
     'command-nightly': 4096,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added support for `gpt-4o-mini` model with a token limit of 128000.
- Added support for `gpt-4o-mini-2024-07-18` model with a token limit of 128000.


___



### **Changes walkthrough** 
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add support for gpt-4o-mini and gpt-4o-mini-2024-07-18 models</code></dd></summary>
<hr>

pr_agent/algo/__init__.py

<li>Added support for <code>gpt-4o-mini</code> model.<br> <li> Added support for <code>gpt-4o-mini-2024-07-18</code> model.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1051/files#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>