### PR TITLE
feat: add aws support for github action

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -540,7 +540,9 @@ def update_settings_from_args(args: List[str]) -> List[str]:
                     continue
                 key, value = _fix_key_value(*vals)
                 get_settings().set(key, value)
-                get_logger().info(f'Updated setting {key} to: "{value}"')
+                # Redact secrets
+                log_value = '[REDACTED]' if key.lower() in ['aws.aws_secret_access_key', 'github.webhook_secret'] else value
+                get_logger().info(f'Updated setting {key} to: "{log_value}"')
             else:
                 other_args.append(arg)
     return other_args

--- a/pr_agent/servers/github_action_runner.py
+++ b/pr_agent/servers/github_action_runner.py
@@ -58,6 +58,13 @@ async def run_action():
         print("OPENAI_KEY not set")
     if OPENAI_ORG:
         get_settings().set("OPENAI.ORG", OPENAI_ORG)
+
+    if get_settings().get("aws.AWS_ACCESS_KEY_ID"):
+        assert get_settings().aws.AWS_SECRET_ACCESS_KEY and get_settings().aws.AWS_REGION_NAME, "AWS credentials are incomplete"
+        os.environ["AWS_ACCESS_KEY_ID"] = get_settings().aws.AWS_ACCESS_KEY_ID
+        os.environ["AWS_SECRET_ACCESS_KEY"] = get_settings().aws.AWS_SECRET_ACCESS_KEY
+        os.environ["AWS_REGION_NAME"] = get_settings().aws.AWS_REGION_NAME
+
     get_settings().set("GITHUB.USER_TOKEN", GITHUB_TOKEN)
     get_settings().set("GITHUB.DEPLOYMENT_TYPE", "user")
     enable_output = get_setting_or_env("GITHUB_ACTION_CONFIG.ENABLE_OUTPUT", True)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added support for AWS credentials in the GitHub Action runner by setting environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION_NAME`.
- Included assertions to ensure that AWS credentials are complete before setting the environment variables.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_action_runner.py</strong><dd><code>Add AWS credentials support in GitHub Action runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/github_action_runner.py

<li>Added AWS credentials support by setting environment variables.<br> <li> Included assertions to ensure AWS credentials are complete.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1060/files#diff-15f9c11da031449998128bdbba057d768853e836eedf44563be71b3847be80e0">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

