### PR TITLE
Implement BitbucketServerProvider.get_line_link

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -248,6 +248,13 @@ class BitbucketServerProvider(GitProvider):
         except Exception as e:
             get_logger().error(f"Failed to publish inline comment to '{file}' at line {from_line}, error: {e}")
             raise e
+        
+    def get_line_link(self, relevant_file: str, relevant_line_start: int, relevant_line_end: int = None) -> str:
+        if relevant_line_start == -1:
+            link = f"{self.pr_url}/diff#{quote_plus(relevant_file)}"
+        else:
+            link = f"{self.pr_url}/diff#{quote_plus(relevant_file)}?t={relevant_line_start}"
+        return link
 
     def generate_link_to_relevant_line_number(self, suggestion) -> str:
         try:


### PR DESCRIPTION
### **User description**
Implements missing BitbucketServerProvider.get_line_link so links in PR review comments generate proper URLs.

Works with #1059

#1058


___

### **PR Type**
enhancement


___

### **Description**
- Implemented the `get_line_link` method in `BitbucketServerProvider` to generate proper URLs for line links in PR review comments.
- The method constructs URLs based on the file and line number, with special handling for cases where the line number is -1.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_server_provider.py</strong><dd><code>Implement `get_line_link` method for BitbucketServerProvider</code></dd></summary>
<hr>

pr_agent/git_providers/bitbucket_server_provider.py

<li>Added <code>get_line_link</code> method to generate proper URLs for line links.<br> <li> Constructed URLs based on file and line number.<br> <li> Included error handling for cases where line number is -1.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1061/files#diff-c9ca96d14ab7a2935714944f8f377c4a9bb425efde19e66595bb58d33e9f5a40">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

