### PR TITLE
refact: redact secrets

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -540,7 +540,9 @@ def update_settings_from_args(args: List[str]) -> List[str]:
                     continue
                 key, value = _fix_key_value(*vals)
                 get_settings().set(key, value)
-                get_logger().info(f'Updated setting {key} to: "{value}"')
+                # Redact secrets
+                log_value = '[REDACTED]' if key.lower() in ['aws.aws_secret_access_key', 'github.webhook_secret'] else value
+                get_logger().info(f'Updated setting {key} to: "{log_value}"')
             else:
                 other_args.append(arg)
     return other_args


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced logging to redact sensitive information such as `aws.aws_secret_access_key` and `github.webhook_secret`.
- Ensured that sensitive values are replaced with `[REDACTED]` in log messages.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Redact sensitive information in logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

<li>Added logic to redact sensitive information in logs.<br> <li> Specifically redacts <code>aws.aws_secret_access_key</code> and <br><code>github.webhook_secret</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1062/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

