### PR TITLE
Improve response cleaning

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -557,7 +557,7 @@ def _fix_key_value(key: str, value: str):
 
 
 def load_yaml(response_text: str, keys_fix_yaml: List[str] = [], first_key="", last_key="") -> dict:
-    response_text = response_text.strip().removeprefix("```yaml").removesuffix("```").strip()
+    response_text = response_text.strip('\n').removeprefix('```yaml').rstrip().removesuffix('```')
     try:
         data = yaml.safe_load(response_text)
     except Exception as e:

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -557,7 +557,7 @@ def _fix_key_value(key: str, value: str):
 
 
 def load_yaml(response_text: str, keys_fix_yaml: List[str] = [], first_key="", last_key="") -> dict:
-    response_text = response_text.strip('\n').removeprefix('```yaml').rstrip('`')
+    response_text = response_text.strip().removeprefix("```yaml").removesuffix("```").strip()
     try:
         data = yaml.safe_load(response_text)
     except Exception as e:


### PR DESCRIPTION
### **User description**
The prompt for the model starts with a code block (```). When testing watsonx models (llama and granite), they would generate the closing block in the response.


___

### **PR Type**
enhancement


___

### **Description**
- Improved the `response_text` cleaning logic in the `load_yaml` function to handle both leading and trailing code block markers more effectively.
- Replaced `rstrip('`')` with `removesuffix("```")` for more precise suffix removal.
- Added additional `strip()` calls to ensure all leading and trailing whitespaces are removed.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Enhance response text cleaning in `load_yaml` function</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

<li>Improved the <code>response_text</code> cleaning logic in <code>load_yaml</code> function.<br> <li> Replaced <code>rstrip('</code>')<code> with </code>removesuffix("<code></code><code>")</code>.<br> <li> Added additional <code>strip()</code> calls for better whitespace handling.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1073/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

