### PR TITLE
Add missing bitbucket_server.pr_commands default

### DIFF
--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -253,6 +253,11 @@ pr_commands = [
 # URL to the BitBucket Server instance
 # url = "https://git.bitbucket.com"
 url = ""
+pr_commands = [
+    "/describe",
+    "/review --pr_reviewer.num_code_suggestions=0",
+    "/improve --pr_code_suggestions.commitable_code_suggestions=true --pr_code_suggestions.suggestions_score_threshold=7",
+]
 
 [litellm]
 # use_client = false


### PR DESCRIPTION
### **User description**
Add missing defaults


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added missing default `pr_commands` for the `bitbucket_server` configuration.
- Included the commands `/describe`, `/review --pr_reviewer.num_code_suggestions=0`, and `/improve --pr_code_suggestions.suggestions_score_threshold=7`.
- Ensured consistency with other default configurations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Add default `pr_commands` for Bitbucket Server configuration</code></dd></summary>
<hr>

pr_agent/settings/configuration.toml

<li>Added default <code>pr_commands</code> for <code>bitbucket_server</code> configuration.<br> <li> Included commands <code>/describe</code>, <code>/review</code>, and <code>/improve</code> with specific <br>parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1075/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

