### PR TITLE
Add warning when summary code suggestions are not supported

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -116,9 +116,14 @@ class PRCodeSuggestions:
 
             if get_settings().config.publish_output:
                 self.git_provider.remove_initial_comment()
-                if ((not get_settings().pr_code_suggestions.commitable_code_suggestions) and
-                        self.git_provider.is_supported("gfm_markdown")):
 
+                post_as_summary = not get_settings().pr_code_suggestions.commitable_code_suggestions
+
+                if post_as_summary and not self.git_provider.is_supported("gfm_markdown"):
+                    get_logger().warning(f"Git provider does not support summary code suggestions. Reverting to commitable_code_suggestions=True.")
+                    post_as_summary = False
+
+                if post_as_summary:
                     # generate summarized suggestions
                     pr_body = self.generate_summarized_suggestions(data)
                     get_logger().debug(f"PR output", artifact=pr_body)


### PR DESCRIPTION
### **User description**
#1074

| commitable_code_suggestions | gfm_markdown | post_as_summary |
| --- | --- | --- |
| false | false | false |
| false | true | true |
| true | false | false |
| true | true | false |


___

### **PR Type**
enhancement, error handling


___

### **Description**
- Added a warning when the Git provider does not support summary code suggestions.
- Introduced a `post_as_summary` variable to manage the decision of posting summarized suggestions.
- Implemented a fallback mechanism to revert to `commitable_code_suggestions=True` if summary suggestions are unsupported.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_code_suggestions.py</strong><dd><code>Add warning and fallback for unsupported summary code suggestions</code></dd></summary>
<hr>

pr_agent/tools/pr_code_suggestions.py

<li>Added a warning when summary code suggestions are not supported by the <br>Git provider.<br> <li> Introduced a <code>post_as_summary</code> variable to control the posting behavior.<br> <li> Reverted to <code>commitable_code_suggestions=True</code> if summary suggestions <br>are not supported.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1078/files#diff-b57ba775e741d6f80bc4f8154b71330c011dae0ac43f3d0197e785b3e6b7117b">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

