### PR TITLE
Use code blocks instead of suggestion blocks for Bitbucket Server multi-line suggestions

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -91,6 +91,8 @@ class BitbucketServerProvider(GitProvider):
                 continue
 
             if relevant_lines_end > relevant_lines_start:
+                # Bitbucket does not support multi-line suggestions so use a code block instead - https://jira.atlassian.com/browse/BSERV-4553
+                body = body.replace("```suggestion", "```")
                 post_parameters = {
                     "body": body,
                     "path": relevant_file,


### PR DESCRIPTION
### **User description**
Workaround for https://jira.atlassian.com/browse/BSERV-4553

#1076


___

### **PR Type**
bug fix, enhancement


___

### **Description**
- Implemented a workaround for the Bitbucket Server multi-line suggestions issue (BSERV-4553) by replacing suggestion blocks with code blocks.
- Modified the `publish_code_suggestions` method in `bitbucket_server_provider.py` to handle multi-line suggestions correctly.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_server_provider.py</strong><dd><code>Workaround for Bitbucket Server multi-line suggestions issue</code></dd></summary>
<hr>

pr_agent/git_providers/bitbucket_server_provider.py

<li>Added a workaround for Bitbucket Server multi-line suggestions issue.<br> <li> Replaced suggestion blocks with code blocks in the <br><code>publish_code_suggestions</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1079/files#diff-c9ca96d14ab7a2935714944f8f377c4a9bb425efde19e66595bb58d33e9f5a40">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

