### PR TITLE
Clarification on webhook URL for Gitlab

### DIFF
--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -55,7 +55,7 @@ WEBHOOK_SECRET=$(python -c "import secrets; print(secrets.token_hex(10))")
     - In the [gitlab] section, fill in personal_access_token and shared_secret. The access token can be a personal access token, or a group or project access token.
     - Set deployment_type to 'gitlab' in [configuration.toml](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml)
    
-5. Create a webhook in GitLab. Set the URL to ````http[s]://<PR_AGENT_HOSTNAME>/webhook````. Set the secret token to the generated secret from step 2.
+5. Create a webhook in GitLab. Set the URL to ```http[s]://<PR_AGENT_HOSTNAME>/webhook```. Set the secret token to the generated secret from step 2.
 In the "Trigger" section, check the ‘comments’ and ‘merge request events’ boxes.
 
 6. Test your installation by opening a merge request or commenting or a merge request using one of CodiumAI's commands.

--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -55,7 +55,7 @@ WEBHOOK_SECRET=$(python -c "import secrets; print(secrets.token_hex(10))")
     - In the [gitlab] section, fill in personal_access_token and shared_secret. The access token can be a personal access token, or a group or project access token.
     - Set deployment_type to 'gitlab' in [configuration.toml](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml)
    
-5. Create a webhook in GitLab. Set the URL to the URL of your app's server. Set the secret token to the generated secret from step 2.
+5. Create a webhook in GitLab. Set the URL to ````http[s]://<PR_AGENT_HOSTNAME>/webhook````. Set the secret token to the generated secret from step 2.
 In the "Trigger" section, check the ‘comments’ and ‘merge request events’ boxes.
 
 6. Test your installation by opening a merge request or commenting or a merge request using one of CodiumAI's commands.


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Updated the GitLab installation instructions to provide a more specific webhook URL format
- Changed step 5 to include the exact URL structure: `http[s]://<PR_AGENT_HOSTNAME>/webhook`
- This clarification helps users correctly set up the webhook for PR Agent with GitLab



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab.md</strong><dd><code>Clarify webhook URL format for GitLab integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/installation/gitlab.md

<li>Updated the instructions for creating a webhook in GitLab<br> <li> Specified the correct URL format for the webhook<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1100/files#diff-568bccbe96a50a16f738f60a0c9f79e9a0c71a68bd4185281218e4aaafd24ed6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

