### PR TITLE
Fix pr_processing.get_pr_multi_diffs

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -70,7 +70,10 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler,
     if total_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD < get_max_tokens(model):
         get_logger().info(f"Tokens: {total_tokens}, total tokens under limit: {get_max_tokens(model)}, "
                           f"returning full diff.")
-        return "\n".join(patches_extended)
+        if patches_extended :
+            return ["\n".join(patches_extended)]
+        else:
+            return []        
 
     # if we are over the limit, start pruning
     get_logger().info(f"Tokens: {total_tokens}, total tokens over limit: {get_max_tokens(model)}, "

--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -70,10 +70,7 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler,
     if total_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD < get_max_tokens(model):
         get_logger().info(f"Tokens: {total_tokens}, total tokens under limit: {get_max_tokens(model)}, "
                           f"returning full diff.")
-        if patches_extended :
-            return ["\n".join(patches_extended)]
-        else:
-            return []        
+        return "\n".join(patches_extended)
 
     # if we are over the limit, start pruning
     get_logger().info(f"Tokens: {total_tokens}, total tokens over limit: {get_max_tokens(model)}, "
@@ -413,7 +410,7 @@ def get_pr_multi_diffs(git_provider: GitProvider,
     patches_extended, total_tokens, patches_extended_tokens = pr_generate_extended_diff(
         pr_languages, token_handler, add_line_numbers_to_hunks=True)
     if total_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD < get_max_tokens(model):
-        return ["\n".join(patches_extended)]
+        return ["\n".join(patches_extended)] if patches_extended else []
 
     patches = []
     final_diff_list = []


### PR DESCRIPTION
### **User description**
Fix function to return an empty list instead of a single joined string when patches_extended is empty.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the `get_pr_diff` function within `pr_agent/algo/pr_processing.py`.
- The function now correctly returns an empty list when `patches_extended` is empty, instead of joining an empty string.
- This change ensures proper handling of cases where there are no patches to process.
- Improves the robustness of the PR diff processing logic.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_processing.py</strong><dd><code>Fix empty patches handling in get_pr_diff</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/pr_processing.py

<li>Modified <code>get_pr_diff</code> function to return an empty list instead of a <br>single joined string when <code>patches_extended</code> is empty.<br> <li> Added a conditional check to handle cases where <code>patches_extended</code> is <br>empty.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1103/files#diff-c2d64de584ef3cb05c9007d72137f6c7ce04c9bc23ce1931760af3a568edb04e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

