### PR TITLE
Fix incorrect logic for extending patch size beyond original file length

### DIFF
--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -51,11 +51,12 @@ def extend_patch(original_file_str, patch_str, patch_extra_lines_before=0, patch
                         extended_start1 = max(1, start1 - patch_extra_lines_before)
                         extended_size1 = size1 + (start1 - extended_start1) + patch_extra_lines_after
                         if extended_start1 - 1 + extended_size1 > len(original_lines):
+                            # we cannot extend beyond the original file
                             extended_size1 = len_original_lines - extended_start1 + 1
                         extended_start2 = max(1, start2 - patch_extra_lines_before)
                         extended_size2 = size2 + (start2 - extended_start2) + patch_extra_lines_after
-                        if extended_start2 - 1 + extended_size2 > len_original_lines:
-                            extended_size2 = len_original_lines - extended_start2 + 1
+                        # if extended_start2 - 1 + extended_size2 > len_original_lines: # incorrect - after the PR, the file may have more lines
+                        #     extended_size2 = len_original_lines - extended_start2 + 1
                         delta_lines = original_lines[extended_start1 - 1:start1 - 1]
                         delta_lines = [f' {line}' for line in delta_lines]
                         if section_header:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the `extend_patch` function where the logic for extending the patch size was incorrect for modified files.
- Removed the check that limited `extended_size2` based on the original file length, as it was not applicable for files that have been modified and potentially increased in size.
- Added a comment explaining why the removed check was incorrect, noting that after the PR, the file may have more lines than the original.
- The fix ensures that patches can be correctly extended for files that have been modified and potentially increased in size during the PR.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git_patch_processing.py</strong><dd><code>Fix patch extension logic for modified files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/git_patch_processing.py

<li>Fixed incorrect logic for extending patch size beyond original file <br>length<br> <li> Removed check that limited extended_size2 based on original file <br>length<br> <li> Added comment explaining why the removed check was incorrect<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1115/files#diff-c5a7f9db4adbcf394c7855f6da656c073d5a6bcc18bd6dede44a8207893174b8">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

