### PR TITLE
Tr/patch extra lines before and after

### DIFF
--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -50,13 +50,13 @@ def extend_patch(original_file_str, patch_str, patch_extra_lines_before=0, patch
                     if patch_extra_lines_before > 0 or patch_extra_lines_after > 0:
                         extended_start1 = max(1, start1 - patch_extra_lines_before)
                         extended_size1 = size1 + (start1 - extended_start1) + patch_extra_lines_after
-                        if extended_start1 - 1 + extended_size1 > len(original_lines):
-                            # we cannot extend beyond the original file
-                            extended_size1 = len_original_lines - extended_start1 + 1
                         extended_start2 = max(1, start2 - patch_extra_lines_before)
                         extended_size2 = size2 + (start2 - extended_start2) + patch_extra_lines_after
-                        # if extended_start2 - 1 + extended_size2 > len_original_lines: # incorrect - after the PR, the file may have more lines
-                        #     extended_size2 = len_original_lines - extended_start2 + 1
+                        if extended_start1 - 1 + extended_size1 > len(original_lines):
+                            # we cannot extend beyond the original file
+                            delta_cap = extended_start1 - 1 + extended_size1 - len(original_lines)
+                            extended_size1 = extended_size1 - delta_cap
+                            extended_size2 = extended_size2 - delta_cap
                         delta_lines = original_lines[extended_start1 - 1:start1 - 1]
                         delta_lines = [f' {line}' for line in delta_lines]
                         if section_header:

--- a/pr_agent/algo/git_patch_processing.py
+++ b/pr_agent/algo/git_patch_processing.py
@@ -55,8 +55,8 @@ def extend_patch(original_file_str, patch_str, patch_extra_lines_before=0, patch
                         if extended_start1 - 1 + extended_size1 > len(original_lines):
                             # we cannot extend beyond the original file
                             delta_cap = extended_start1 - 1 + extended_size1 - len(original_lines)
-                            extended_size1 = extended_size1 - delta_cap
-                            extended_size2 = extended_size2 - delta_cap
+                            extended_size1 = max(extended_size1 - delta_cap, size1)
+                            extended_size2 = max(extended_size2 - delta_cap, size2)
                         delta_lines = original_lines[extended_start1 - 1:start1 - 1]
                         delta_lines = [f' {line}' for line in delta_lines]
                         if section_header:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue in the `extend_patch` function where the patch extension logic could potentially exceed the original file length.
- Introduced a `delta_cap` variable to calculate the difference between the extended size and the original file length.
- Modified the adjustment of `extended_size1` and `extended_size2` to ensure they don't exceed the original file length while maintaining at least the original patch size.
- Removed outdated comments and consolidated the logic for both `extended_size1` and `extended_size2`.
- This change improves the robustness of the patch extension process, particularly in cases where the extended size would have exceeded the original file boundaries.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git_patch_processing.py</strong><dd><code>Improve patch extension logic for file size constraints</code>&nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/git_patch_processing.py

<li>Modified the logic for extending patches when the extended size <br>exceeds the original file length<br> <li> Introduced a <code>delta_cap</code> variable to calculate the difference between <br>extended size and original file length<br> <li> Adjusted <code>extended_size1</code> and <code>extended_size2</code> to ensure they don't exceed <br>the original file length while maintaining the minimum size<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1116/files#diff-c5a7f9db4adbcf394c7855f6da656c073d5a6bcc18bd6dede44a8207893174b8">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

