### PR TITLE
Hl/limit long comments

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -147,13 +147,13 @@ class LiteLLMAIHandler(BaseAiHandler):
 
             response = await acompletion(**kwargs)
         except (openai.APIError, openai.APITimeoutError) as e:
-            get_logger().error("Error during OpenAI inference: ", e)
+            get_logger().warning("Error during OpenAI inference: ", e)
             raise
         except (openai.RateLimitError) as e:
             get_logger().error("Rate limit error during OpenAI inference: ", e)
             raise
         except (Exception) as e:
-            get_logger().error("Unknown error during OpenAI inference: ", e)
+            get_logger().warning("Unknown error during OpenAI inference: ", e)
             raise openai.APIError from e
         if response is None or len(response["choices"]) == 0:
             raise openai.APIError

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -30,6 +30,7 @@ class BitbucketProvider(GitProvider):
         s.headers["Content-Type"] = "application/json"
         self.headers = s.headers
         self.bitbucket_client = Cloud(session=s)
+        self.max_comment_length = 31000
         self.workspace_slug = None
         self.repo_slug = None
         self.repo = None
@@ -211,6 +212,7 @@ class BitbucketProvider(GitProvider):
         self.publish_comment(pr_comment)
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
+        pr_comment = self.limit_output_characters(pr_comment, self.max_comment_length)
         comment = self.pr.comment(pr_comment)
         if is_temporary:
             self.temp_comments.append(comment["id"])
@@ -218,6 +220,7 @@ class BitbucketProvider(GitProvider):
 
     def edit_comment(self, comment, body: str):
         try:
+            body = self.limit_output_characters(body, self.max_comment_length)
             comment.update(body)
         except Exception as e:
             get_logger().exception(f"Failed to update comment, error: {e}")
@@ -237,6 +240,7 @@ class BitbucketProvider(GitProvider):
 
     # function to create_inline_comment
     def create_inline_comment(self, body: str, relevant_file: str, relevant_line_in_file: str, absolute_position: int = None):
+        body = self.limit_output_characters(body, self.max_comment_length)
         position, absolute_position = find_line_number_of_relevant_line_in_file(self.get_diff_files(),
                                                                             relevant_file.strip('`'),
                                                                             relevant_line_in_file, absolute_position)
@@ -251,6 +255,7 @@ class BitbucketProvider(GitProvider):
 
 
     def publish_inline_comment(self, comment: str, from_line: int, file: str):
+        comment = self.limit_output_characters(comment, self.max_comment_length)
         payload = json.dumps( {
             "content": {
                 "raw": comment,

--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -256,6 +256,9 @@ class GitProvider(ABC):
         except Exception as e:
             return -1
 
+    def limit_output_characters(self, output: str, max_chars: int):
+        return output[:max_chars] + '...' if len(output) > max_chars else output
+
 
 def get_main_pr_language(languages, files) -> str:
     """
@@ -324,6 +327,8 @@ def get_main_pr_language(languages, files) -> str:
         pass
 
     return main_language_str
+
+
 
 
 class IncrementalPR:


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implemented comment length limitations for Bitbucket, GitHub, and GitLab providers to prevent issues with excessively long comments.
- Added a utility method `limit_output_characters` in the base `GitProvider` class to truncate long strings.
- Set maximum comment lengths: 31000 characters for Bitbucket and 65000 characters for GitHub and GitLab.
- Applied the character limit to various comment-related methods across all providers.
- Adjusted error logging levels in the LiteLLM AI handler, changing some errors to warnings for OpenAI inference issues.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm_ai_handler.py</strong><dd><code>Adjust error logging levels for OpenAI inference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/ai_handlers/litellm_ai_handler.py

<li>Changed error logging to warning for OpenAI inference errors<br> <li> Adjusted error handling for unknown errors during OpenAI inference<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1119/files#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfe">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_provider.py</strong><dd><code>Implement comment length limitation for Bitbucket</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/bitbucket_provider.py

<li>Added max_comment_length attribute set to 31000 characters<br> <li> Implemented character limit for comments in various methods<br> <li> Applied limit_output_characters method to truncate long comments<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1119/files#diff-3f47323db85f534fa282b2d48c6cf542f00a5e791b62379253ef3d3e8c6bb3b2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>git_provider.py</strong><dd><code>Add utility method for limiting output length</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/git_provider.py

- Added limit_output_characters method to truncate long strings



</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1119/files#diff-52d45f12b836f77ed1aef86e972e65404634ea4e2a6083fb71a9b0f9bb9e062f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>github_provider.py</strong><dd><code>Implement comment length limitation for GitHub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/github_provider.py

<li>Added max_comment_chars attribute set to 65000 characters<br> <li> Implemented character limit for comments in various methods<br> <li> Applied limit_output_characters method to truncate long comments<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1119/files#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gitlab_provider.py</strong><dd><code>Implement comment length limitation for GitLab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gitlab_provider.py

<li>Added max_comment_chars attribute set to 65000 characters<br> <li> Implemented character limit for comments in various methods<br> <li> Applied limit_output_characters method to truncate long comments<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1119/files#diff-35acba7a2829983fcf3c3c6a69b135988227e503ccdfa94366d1b48fcbbb0a31">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

