### PR TITLE
Fix base url not being passed through github_provider class correctly

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -29,6 +29,8 @@ class GithubProvider(GitProvider):
         self.max_comment_chars = 65000
         self.base_url = get_settings().get("GITHUB.BASE_URL", "https://api.github.com").rstrip("/")
         self.base_url_html = self.base_url.split("api/")[0].rstrip("/") if "api/" in self.base_url else "https://github.com"
+        self.base_domain = self.base_url.replace("https://", "").replace("http://", "")
+        self.base_domain_html = self.base_url_html.replace("https://", "").replace("http://", "")
         self.github_client = self._get_github_client()
         self.repo = None
         self.pr_num = None
@@ -609,7 +611,7 @@ class GithubProvider(GitProvider):
         parsed_url = urlparse(pr_url)
 
         path_parts = parsed_url.path.strip('/').split('/')
-        if self.base_url in parsed_url.netloc:
+        if self.base_domain in parsed_url.netloc:
             if len(path_parts) < 5 or path_parts[3] != 'pulls':
                 raise ValueError("The provided URL does not appear to be a GitHub PR URL")
             repo_name = '/'.join(path_parts[1:3])
@@ -633,7 +635,7 @@ class GithubProvider(GitProvider):
     def _parse_issue_url(self, issue_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(issue_url)
         path_parts = parsed_url.path.strip('/').split('/')
-        if self.base_url in parsed_url.netloc:
+        if self.base_domain in parsed_url.netloc:
             if len(path_parts) < 5 or path_parts[3] != 'issues':
                 raise ValueError("The provided URL does not appear to be a GitHub ISSUE URL")
             repo_name = '/'.join(path_parts[1:3])

--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -605,12 +605,11 @@ class GithubProvider(GitProvider):
             get_logger().exception(f"Failed to remove eyes reaction, error: {e}")
             return False
 
-    @staticmethod
-    def _parse_pr_url(pr_url: str) -> Tuple[str, int]:
+    def _parse_pr_url(self, pr_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(pr_url)
 
         path_parts = parsed_url.path.strip('/').split('/')
-        if 'api.github.com' in parsed_url.netloc:
+        if self.base_url in parsed_url.netloc:
             if len(path_parts) < 5 or path_parts[3] != 'pulls':
                 raise ValueError("The provided URL does not appear to be a GitHub PR URL")
             repo_name = '/'.join(path_parts[1:3])
@@ -631,11 +630,10 @@ class GithubProvider(GitProvider):
 
         return repo_name, pr_number
 
-    @staticmethod
-    def _parse_issue_url(issue_url: str) -> Tuple[str, int]:
+    def _parse_issue_url(self, issue_url: str) -> Tuple[str, int]:
         parsed_url = urlparse(issue_url)
         path_parts = parsed_url.path.strip('/').split('/')
-        if 'api.github.com' in parsed_url.netloc:
+        if self.base_url in parsed_url.netloc:
             if len(path_parts) < 5 or path_parts[3] != 'issues':
                 raise ValueError("The provided URL does not appear to be a GitHub ISSUE URL")
             repo_name = '/'.join(path_parts[1:3])
@@ -829,7 +827,7 @@ class GithubProvider(GitProvider):
         """
         line_start = component_range.line_start + 1
         line_end = component_range.line_end + 1
-        link = (f"https://github.com/{self.repo}/blob/{self.last_commit_id.sha}/{filepath}/"
+        link = (f"{self.base_url_html}/{self.repo}/blob/{self.last_commit_id.sha}/{filepath}/"
                 f"#L{line_start}-L{line_end}")
         return link
 


### PR DESCRIPTION
### **User description**
- the base_url and base_url_html attributes were not being fully passed through the code 
- this pr fixes that and removes the hard coded github.com references throughout the code

all unit tests passing 

![image](https://github.com/user-attachments/assets/974f7d44-8958-4034-abc1-dc0fb67dd504)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed issue where `base_url` and `base_url_html` attributes were not being correctly used throughout the `GitHubProvider` class.
- Refactored `_parse_pr_url` and `_parse_issue_url` methods from static to instance methods to access `self.base_url`.
- Updated `get_lines_link_original_file` method to use `self.base_url_html` instead of hardcoded 'github.com'.
- Removed hardcoded references to 'github.com' and 'api.github.com' throughout the code.
- These changes improve flexibility and allow the class to work with different GitHub instances or Enterprise GitHub setups.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_provider.py</strong><dd><code>Refactor GitHub provider to use instance-specific base URLs</code></dd></summary>
<hr>

pr_agent/git_providers/github_provider.py

<li>Replaced static methods with instance methods for <code>_parse_pr_url</code> and <br><code>_parse_issue_url</code><br> <li> Updated URL parsing to use <code>self.base_url</code> instead of hardcoded <br>'api.github.com'<br> <li> Modified <code>get_lines_link_original_file</code> to use <code>self.base_url_html</code> <br>instead of hardcoded 'github.com'<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1127/files#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

