### PR TITLE
fix: remove CI_MERGE_REQUEST_STATE as is not a Gitlab variable

### DIFF
--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -23,7 +23,7 @@ pr_agent_job:
     - python -m pr_agent.cli --pr_url="$MR_URL" review
     - python -m pr_agent.cli --pr_url="$MR_URL" improve
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_STATE == "opened"'
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
 ```
 This script will run PR-Agent on every new merge request. You can modify the `rules` section to run PR-Agent on different events.
 You can also modify the `script` section to run different PR-Agent commands, or with different parameters by exporting different environment variables.


### PR DESCRIPTION
### **User description**
As per the subject, the variable is not a default GitLab variable and must be removed.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Removed the `CI_MERGE_REQUEST_STATE` variable from the GitLab CI job rule as it is not a default GitLab variable
- Simplified the job rule to run PR-Agent on all merge request events, not just opened ones
- Updated the documentation to reflect the changes in the GitLab CI configuration
- This change ensures that PR-Agent will run on all merge request events, improving its coverage and effectiveness



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab.md</strong><dd><code>Update GitLab CI job rule for PR-Agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/installation/gitlab.md

<li>Removed the condition <code>$CI_MERGE_REQUEST_STATE == "opened"</code> from the <br>GitLab CI job rule<br> <li> Simplified the job rule to only check if the pipeline source is a <br>merge request event<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1161/files#diff-568bccbe96a50a16f738f60a0c9f79e9a0c71a68bd4185281218e4aaafd24ed6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

