### PR TITLE
feat: handle gitlab MR draft status

### DIFF
--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -124,7 +124,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
         log_context["sender"] = sender
-        should_skip_draft = get_settings().get("GITLAB.SKIP_DRAFT_MR", False)
+        should_skip_draft = get_settings().get("GITLAB.SKIP_DRAFT_MR", True)
         if data.get('object_kind') == 'merge_request' and data['object_attributes'].get('action') in ['open', 'reopen']:
             url = data['object_attributes'].get('url')
             draft = data['object_attributes'].get('draft')

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -124,7 +124,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
         log_context["sender"] = sender
-        should_skip_draft = get_settings().get("GITLAB.SKIP_DRAFT_MR", True)
+        should_skip_draft = get_settings().get("GITLAB.SKIP_DRAFT_MR", False)
         if data.get('object_kind') == 'merge_request' and data['object_attributes'].get('action') in ['open', 'reopen']:
             url = data['object_attributes'].get('url')
             draft = data['object_attributes'].get('draft')

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -124,13 +124,12 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
         log_context["sender"] = sender
-        should_skip_draft = get_settings().get("GITLAB.SKIP_DRAFT_MR", False)
         if data.get('object_kind') == 'merge_request' and data['object_attributes'].get('action') in ['open', 'reopen']:
             url = data['object_attributes'].get('url')
             draft = data['object_attributes'].get('draft')
             get_logger().info(f"New merge request: {url}")
 
-            if draft and should_skip_draft:
+            if draft:
                 get_logger().info(f"Skipping draft MR: {url}")
                 return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
@@ -140,7 +139,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
                 mr = data['merge_request']
                 url = mr.get('url')
                 draft = mr.get('draft')
-                if draft and should_skip_draft:
+                if draft:
                     get_logger().info(f"Skipping draft MR: {url}")
                     return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -230,7 +230,6 @@ push_commands = [
     "/describe",
     "/review --pr_reviewer.num_code_suggestions=0",
 ]
-skip_draft_mr = false
 
 [bitbucket_app]
 pr_commands = [

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -230,6 +230,7 @@ push_commands = [
     "/describe",
     "/review --pr_reviewer.num_code_suggestions=0",
 ]
+skip_draft_mr = false
 
 [bitbucket_app]
 pr_commands = [


### PR DESCRIPTION
### **User description**
closes #1160

As reported in the issue, this MR adds the possibility to skip MR in draft status, default is false when enabled every command is logged and discarded.


___

### **PR Type**
Enhancement


___

### **Description**
- Added functionality to handle GitLab merge requests (MRs) in draft status
- Implemented logic to skip processing of draft MRs:
  - For newly opened or reopened MRs
  - For comments on existing MRs
- Added logging to inform when a draft MR is being skipped
- This change allows for more efficient processing by ignoring MRs that are not ready for review



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab_webhook.py</strong><dd><code>Handle GitLab merge request draft status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/gitlab_webhook.py

<li>Added logic to check if a merge request is in draft status<br> <li> Implemented skipping of draft merge requests for both new MRs and <br>comments on existing MRs<br> <li> Logged information about skipping draft MRs<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1165/files#diff-c3ea1ba460930c6e6e6a2c36a7dc729d79730a96e872d40ffb246f80bc7c0880">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

