### PR TITLE
Bugfix/bb 2 way diff fix

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -156,8 +156,10 @@ class BitbucketServerProvider(GitProvider):
         guaranteed_common_ancestor = source_commits_list[-1]['parents'][0]['id']
         destination_commits = list(self.bitbucket_client.get_commits(self.workspace_slug, self.repo_slug, guaranteed_common_ancestor, self.pr.toRef['latestCommit']))
 
-        base_sha = self.get_best_common_ancestor(source_commits_list, destination_commits, guaranteed_common_ancestor)
+        base_sha = self.pr.toRef['latestCommit']
         head_sha = self.pr.fromRef['latestCommit']
+        if not get_settings().bitbucket_server.get("legacy_diff_calculation", False):
+            base_sha = self.get_best_common_ancestor(source_commits_list, destination_commits, guaranteed_common_ancestor)
 
         diff_files = []
         original_file_content_str = ""

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -1,9 +1,9 @@
+from distutils.version import LooseVersion
+from requests.exceptions import HTTPError
 from typing import Optional, Tuple
 from urllib.parse import quote_plus, urlparse
 
-from requests.exceptions import HTTPError
 from atlassian.bitbucket import Bitbucket
-from starlette_context import context
 
 from .git_provider import GitProvider
 from ..algo.types import EDIT_TYPE, FilePatchInfo
@@ -34,6 +34,10 @@ class BitbucketServerProvider(GitProvider):
         self.bitbucket_client = bitbucket_client or Bitbucket(url=self.bitbucket_server_url,
                                                               token=get_settings().get("BITBUCKET_SERVER.BEARER_TOKEN",
                                                                                        None))
+        try:
+            self.bitbucket_api_version = LooseVersion(self.bitbucket_client.get("rest/api/1.0/application-properties").get('version'))
+        except Exception:
+            self.bitbucket_api_version = None
 
         if pr_url:
             self.set_pr(pr_url)
@@ -152,14 +156,34 @@ class BitbucketServerProvider(GitProvider):
         if self.diff_files:
             return self.diff_files
 
-        source_commits_list = list(self.bitbucket_client.get_pull_requests_commits(self.workspace_slug, self.repo_slug, self.pr_num))
-        guaranteed_common_ancestor = source_commits_list[-1]['parents'][0]['id']
-        destination_commits = list(self.bitbucket_client.get_commits(self.workspace_slug, self.repo_slug, guaranteed_common_ancestor, self.pr.toRef['latestCommit']))
+        source_commits_list = list(self.bitbucket_client.get_pull_requests_commits(
+            self.workspace_slug,
+            self.repo_slug,
+            self.pr_num
+        ))
 
-        base_sha = self.pr.toRef['latestCommit']
-        head_sha = self.pr.fromRef['latestCommit']
-        if not get_settings().bitbucket_server.get("legacy_diff_calculation", False):
-            base_sha = self.get_best_common_ancestor(source_commits_list, destination_commits, guaranteed_common_ancestor)
+        # defaults to basic diff functionality with a guaranteed common ancestor
+        base_sha, head_sha = source_commits_list[-1]['parents'][0]['id'], source_commits_list[0]['id']
+
+        # if Bitbucket api version is greater than or equal to 7.0 then use 2-way diff functionality for the base_sha
+        if self.bitbucket_api_version is not None and self.bitbucket_api_version >= LooseVersion("7.0"):
+            # Bitbucket endpoint for getting merge-base is available as of 8.16
+            if self.bitbucket_api_version >= LooseVersion("8.16"):
+                try:
+                    base_sha = self.bitbucket_client.get(self._get_best_common_ancestor())['id']
+                except Exception as e:
+                    get_logger().error(f"Failed to get the best common ancestor for PR: {self.pr_url}, \nerror: {e}")
+                    raise e
+            # for versions 7.0-8.15 try to calculate the merge-base on our own
+            else:
+                try:
+                    destination_commits = list(
+                        self.bitbucket_client.get_commits(self.workspace_slug, self.repo_slug, base_sha,
+                                                          self.pr.toRef['latestCommit']))
+                    base_sha = self.get_best_common_ancestor(source_commits_list, destination_commits, base_sha)
+                except Exception as e:
+                    get_logger().error(f"Failed to get the commit list for calculating best common ancestor for PR: {self.pr_url}, \nerror: {e}")
+                    raise e
 
         diff_files = []
         original_file_content_str = ""
@@ -427,3 +451,6 @@ class BitbucketServerProvider(GitProvider):
 
     def _get_pr_comments_path(self):
         return f"rest/api/latest/projects/{self.workspace_slug}/repos/{self.repo_slug}/pull-requests/{self.pr_num}/comments"
+
+    def _get_best_common_ancestor(self):
+        return f"rest/api/latest/projects/{self.workspace_slug}/repos/{self.repo_slug}/pull-requests/{self.pr_num}/merge-base"

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -139,8 +139,7 @@ class BitbucketServerProvider(GitProvider):
     #gets the best common ancestor: https://git-scm.com/docs/git-merge-base
     @staticmethod
     def get_best_common_ancestor(source_commits_list, destination_commits_list, guaranteed_common_ancestor) -> str:
-        destination_commit_hashes = {commit['id'] for commit in destination_commits_list}
-        destination_commit_hashes.add(guaranteed_common_ancestor)
+        destination_commit_hashes = {commit['id'] for commit in destination_commits_list} | {guaranteed_common_ancestor}
 
         for commit in source_commits_list:
             for parent_commit in commit['parents']:

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -144,7 +144,7 @@ class BitbucketServerProvider(GitProvider):
 
         for commit in source_commits_list:
             for parent_commit in commit['parents']:
-                if commit['id'] in destination_commit_hashes or parent_commit['id'] in destination_commit_hashes:
+                if parent_commit['id'] in destination_commit_hashes:
                     return parent_commit['id']
 
         return guaranteed_common_ancestor

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -263,6 +263,7 @@ pr_commands = [
     "/review --pr_reviewer.num_code_suggestions=0",
     "/improve --pr_code_suggestions.commitable_code_suggestions=true --pr_code_suggestions.suggestions_score_threshold=7",
 ]
+legacy_diff_calculation = false
 
 [litellm]
 # use_client = false

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -263,7 +263,6 @@ pr_commands = [
     "/review --pr_reviewer.num_code_suggestions=0",
     "/improve --pr_code_suggestions.commitable_code_suggestions=true --pr_code_suggestions.suggestions_score_threshold=7",
 ]
-legacy_diff_calculation = false
 
 [litellm]
 # use_client = false

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -1,5 +1,8 @@
 from pr_agent.git_providers import BitbucketServerProvider
 from pr_agent.git_providers.bitbucket_provider import BitbucketProvider
+from unittest.mock import MagicMock
+from atlassian.bitbucket import Bitbucket
+from pr_agent.algo.types import EDIT_TYPE, FilePatchInfo
 
 
 class TestBitbucketProvider:
@@ -10,9 +13,205 @@ class TestBitbucketProvider:
         assert repo_slug == "MY_TEST_REPO"
         assert pr_number == 321
 
-    def test_bitbucket_server_pr_url(self):
+
+class TestBitbucketServerProvider:
+    def test_parse_pr_url(self):
         url = "https://git.onpreminstance.com/projects/AAA/repos/my-repo/pull-requests/1"
         workspace_slug, repo_slug, pr_number = BitbucketServerProvider._parse_pr_url(url)
         assert workspace_slug == "AAA"
         assert repo_slug == "my-repo"
         assert pr_number == 1
+
+    def mock_get_content_of_file(self, project_key, repository_slug, filename, at=None, markup=None):
+        if at == '9c1cffdd9f276074bfb6fb3b70fbee62d298b058':
+            return 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile\n'
+        elif at == '2a1165446bdf991caf114d01f7c88d84ae7399cf':
+            return 'file\nwith\nmultiple \nlines\nto\nemulate\na\nfake\nfile\n'
+        elif at == 'f617708826cdd0b40abb5245eda71630192a17e3':
+            return 'file\nwith\nmultiple \nlines\nto\nemulate\na\nreal\nfile\n'
+        elif at == 'cb68a3027d6dda065a7692ebf2c90bed1bcdec28':
+            return 'file\nwith\nsome\nchanges\nto\nemulate\na\nreal\nfile\n'
+        elif at == '1905dcf16c0aac6ac24f7ab617ad09c73dc1d23b':
+            return 'file\nwith\nsome\nlines\nto\nemulate\na\nfake\ntest\n'
+        elif at == 'ae4eca7f222c96d396927d48ab7538e2ee13ca63':
+            return 'readme\nwithout\nsome\nlines\nto\nsimulate\na\nreal\nfile'
+        elif at == '548f8ba15abc30875a082156314426806c3f4d97':
+            return 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile'
+        return ''
+
+    '''
+    tests the 2-way diff functionality where the diff should be between the HEAD of branch b and node c
+    NOT between the HEAD of main and the HEAD of branch b
+
+          - o  branch b
+         /
+    o - o - o  main
+        ^ node c
+    '''
+
+    def test_get_diff_files_simple_diverge(self):
+        bitbucket_client = MagicMock(Bitbucket)
+        bitbucket_client.get_pull_request.return_value = {
+            'toRef': {'latestCommit': '9c1cffdd9f276074bfb6fb3b70fbee62d298b058'},
+            'fromRef': {'latestCommit': '2a1165446bdf991caf114d01f7c88d84ae7399cf'}
+        }
+        bitbucket_client.get_pull_requests_commits.return_value = [
+            {'id': '2a1165446bdf991caf114d01f7c88d84ae7399cf',
+             'parents': [{'id': 'f617708826cdd0b40abb5245eda71630192a17e3'}]}
+        ]
+        bitbucket_client.get_commits.return_value = [
+            {'id': '9c1cffdd9f276074bfb6fb3b70fbee62d298b058'},
+            {'id': 'dbca09554567d2e4bee7f07993390153280ee450'}
+        ]
+        bitbucket_client.get_pull_requests_changes.return_value = [
+            {
+                'path': {'toString': 'Readme.md'},
+                'type': 'MODIFY',
+            }
+        ]
+
+        bitbucket_client.get_content_of_file.side_effect = self.mock_get_content_of_file
+
+        provider = BitbucketServerProvider(
+            "https://git.onpreminstance.com/projects/AAA/repos/my-repo/pull-requests/1",
+            bitbucket_client=bitbucket_client
+        )
+
+        expected = [
+            FilePatchInfo(
+                'file\nwith\nmultiple \nlines\nto\nemulate\na\nreal\nfile\n',
+                'file\nwith\nmultiple \nlines\nto\nemulate\na\nfake\nfile\n',
+                '--- \n+++ \n@@ -5,5 +5,5 @@\n to\n emulate\n a\n-real\n+fake\n file\n',
+                'Readme.md',
+                edit_type=EDIT_TYPE.MODIFIED,
+            )
+        ]
+
+        actual = provider.get_diff_files()
+
+        assert actual == expected
+
+    '''
+    tests the 2-way diff functionality where the diff should be between the HEAD of branch b and node c
+    NOT between the HEAD of main and the HEAD of branch b
+
+          - o - o - o  branch b
+         /     /  
+    o - o -- o - o     main
+             ^ node c
+    '''
+
+    def test_get_diff_files_diverge_with_merge_commit(self):
+        bitbucket_client = MagicMock(Bitbucket)
+        bitbucket_client.get_pull_request.return_value = {
+            'toRef': {'latestCommit': 'cb68a3027d6dda065a7692ebf2c90bed1bcdec28'},
+            'fromRef': {'latestCommit': '1905dcf16c0aac6ac24f7ab617ad09c73dc1d23b'}
+        }
+        bitbucket_client.get_pull_requests_commits.return_value = [
+            {'id': '1905dcf16c0aac6ac24f7ab617ad09c73dc1d23b',
+             'parents': [{'id': '692772f456c3db77a90b11ce39ea516f8c2bad93'}]},
+            {'id': '692772f456c3db77a90b11ce39ea516f8c2bad93', 'parents': [
+                {'id': '2a1165446bdf991caf114d01f7c88d84ae7399cf'},
+                {'id': '9c1cffdd9f276074bfb6fb3b70fbee62d298b058'},
+            ]},
+            {'id': '2a1165446bdf991caf114d01f7c88d84ae7399cf',
+             'parents': [{'id': 'f617708826cdd0b40abb5245eda71630192a17e3'}]}
+        ]
+        bitbucket_client.get_commits.return_value = [
+            {'id': 'cb68a3027d6dda065a7692ebf2c90bed1bcdec28'},
+            {'id': '9c1cffdd9f276074bfb6fb3b70fbee62d298b058'},
+            {'id': 'dbca09554567d2e4bee7f07993390153280ee450'}
+        ]
+        bitbucket_client.get_pull_requests_changes.return_value = [
+            {
+                'path': {'toString': 'Readme.md'},
+                'type': 'MODIFY',
+            }
+        ]
+
+        bitbucket_client.get_content_of_file.side_effect = self.mock_get_content_of_file
+
+        provider = BitbucketServerProvider(
+            "https://git.onpreminstance.com/projects/AAA/repos/my-repo/pull-requests/1",
+            bitbucket_client=bitbucket_client
+        )
+
+        expected = [
+            FilePatchInfo(
+                'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile\n',
+                'file\nwith\nsome\nlines\nto\nemulate\na\nfake\ntest\n',
+                '--- \n+++ \n@@ -5,5 +5,5 @@\n to\n emulate\n a\n-real\n-file\n+fake\n+test\n',
+                'Readme.md',
+                edit_type=EDIT_TYPE.MODIFIED,
+            )
+        ]
+
+        actual = provider.get_diff_files()
+
+        assert actual == expected
+
+    '''
+    tests the 2-way diff functionality where the diff should be between the HEAD of branch c and node d
+    NOT between the HEAD of main and the HEAD of branch c
+
+            ---- o - o branch c
+           /    /
+          ---- o       branch b
+         /    /  
+        o - o - o      main
+            ^ node d
+    '''
+
+    def test_get_diff_files_multi_merge_diverge(self):
+        bitbucket_client = MagicMock(Bitbucket)
+        bitbucket_client.get_pull_request.return_value = {
+            'toRef': {'latestCommit': '9569922b22fe4fd0968be6a50ed99f71efcd0504'},
+            'fromRef': {'latestCommit': 'ae4eca7f222c96d396927d48ab7538e2ee13ca63'}
+        }
+        bitbucket_client.get_pull_requests_commits.return_value = [
+            {'id': 'ae4eca7f222c96d396927d48ab7538e2ee13ca63',
+             'parents': [{'id': 'bbf300fb3af5129af8c44659f8cc7a526a6a6f31'}]},
+            {'id': 'bbf300fb3af5129af8c44659f8cc7a526a6a6f31', 'parents': [
+                {'id': '10b7b8e41cb370b48ceda8da4e7e6ad033182213'},
+                {'id': 'd1bb183c706a3ebe4c2b1158c25878201a27ad8c'},
+            ]},
+            {'id': 'd1bb183c706a3ebe4c2b1158c25878201a27ad8c', 'parents': [
+                {'id': '5bd76251866cb415fc5ff232f63a581e89223bda'},
+                {'id': '548f8ba15abc30875a082156314426806c3f4d97'}
+            ]},
+            {'id': '5bd76251866cb415fc5ff232f63a581e89223bda',
+             'parents': [{'id': '0e898cb355a5170d8c8771b25d43fcaa1d2d9489'}]},
+            {'id': '10b7b8e41cb370b48ceda8da4e7e6ad033182213',
+             'parents': [{'id': '0e898cb355a5170d8c8771b25d43fcaa1d2d9489'}]}
+        ]
+        bitbucket_client.get_commits.return_value = [
+            {'id': '9569922b22fe4fd0968be6a50ed99f71efcd0504'},
+            {'id': '548f8ba15abc30875a082156314426806c3f4d97'}
+        ]
+        bitbucket_client.get_pull_requests_changes.return_value = [
+            {
+                'path': {'toString': 'Readme.md'},
+                'type': 'MODIFY',
+            }
+        ]
+
+        bitbucket_client.get_content_of_file.side_effect = self.mock_get_content_of_file
+
+        provider = BitbucketServerProvider(
+            "https://git.onpreminstance.com/projects/AAA/repos/my-repo/pull-requests/1",
+            bitbucket_client=bitbucket_client
+        )
+
+        expected = [
+            FilePatchInfo(
+                'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile',
+                'readme\nwithout\nsome\nlines\nto\nsimulate\na\nreal\nfile',
+                '--- \n+++ \n@@ -1,9 +1,9 @@\n-file\n-with\n+readme\n+without\n some\n lines\n to\n-emulate\n+simulate\n a\n real\n file',
+                'Readme.md',
+                edit_type=EDIT_TYPE.MODIFIED,
+            )
+        ]
+
+        actual = provider.get_diff_files()
+
+        assert actual == expected

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -23,21 +23,17 @@ class TestBitbucketServerProvider:
         assert pr_number == 1
 
     def mock_get_content_of_file(self, project_key, repository_slug, filename, at=None, markup=None):
-        if at == '9c1cffdd9f276074bfb6fb3b70fbee62d298b058':
-            return 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile\n'
-        elif at == '2a1165446bdf991caf114d01f7c88d84ae7399cf':
-            return 'file\nwith\nmultiple \nlines\nto\nemulate\na\nfake\nfile\n'
-        elif at == 'f617708826cdd0b40abb5245eda71630192a17e3':
-            return 'file\nwith\nmultiple \nlines\nto\nemulate\na\nreal\nfile\n'
-        elif at == 'cb68a3027d6dda065a7692ebf2c90bed1bcdec28':
-            return 'file\nwith\nsome\nchanges\nto\nemulate\na\nreal\nfile\n'
-        elif at == '1905dcf16c0aac6ac24f7ab617ad09c73dc1d23b':
-            return 'file\nwith\nsome\nlines\nto\nemulate\na\nfake\ntest\n'
-        elif at == 'ae4eca7f222c96d396927d48ab7538e2ee13ca63':
-            return 'readme\nwithout\nsome\nlines\nto\nsimulate\na\nreal\nfile'
-        elif at == '548f8ba15abc30875a082156314426806c3f4d97':
-            return 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile'
-        return ''
+        content_map = {
+            '9c1cffdd9f276074bfb6fb3b70fbee62d298b058': 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile\n',
+            '2a1165446bdf991caf114d01f7c88d84ae7399cf': 'file\nwith\nmultiple \nlines\nto\nemulate\na\nfake\nfile\n',
+            'f617708826cdd0b40abb5245eda71630192a17e3': 'file\nwith\nmultiple \nlines\nto\nemulate\na\nreal\nfile\n',
+            'cb68a3027d6dda065a7692ebf2c90bed1bcdec28': 'file\nwith\nsome\nchanges\nto\nemulate\na\nreal\nfile\n',
+            '1905dcf16c0aac6ac24f7ab617ad09c73dc1d23b': 'file\nwith\nsome\nlines\nto\nemulate\na\nfake\ntest\n',
+            'ae4eca7f222c96d396927d48ab7538e2ee13ca63': 'readme\nwithout\nsome\nlines\nto\nsimulate\na\nreal\nfile',
+            '548f8ba15abc30875a082156314426806c3f4d97': 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile'
+        }
+
+        return content_map.get(at, '')
 
     '''
     tests the 2-way diff functionality where the diff should be between the HEAD of branch b and node c


### PR DESCRIPTION
### **User description**
Fixes #1131 

Gets the 2-way file diff between the merging branch head and the best common ancestor


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed issue #1131: Implemented correct 2-way file diff calculation for Bitbucket Server
- Enhanced `BitbucketServerProvider` class to find the best common ancestor (merge base) between branches
- Updated `get_diff_files` method to use the correct base commit for diff calculation
- Added comprehensive unit tests to verify the correct behavior of the 2-way diff functionality
- Improved code flexibility by allowing injection of a custom `bitbucket_client` in the constructor



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_server_provider.py</strong><dd><code>Improve BitbucketServerProvider diff calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/bitbucket_server_provider.py

<li>Added optional <code>bitbucket_client</code> parameter to the constructor<br> <li> Implemented <code>get_best_common_ancestor</code> method to find the merge base<br> <li> Updated <code>get_diff_files</code> to use the best common ancestor for diff <br>calculation<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1172/files#diff-c9ca96d14ab7a2935714944f8f377c4a9bb425efde19e66595bb58d33e9f5a40">+23/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bitbucket_provider.py</strong><dd><code>Add comprehensive tests for BitbucketServerProvider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_bitbucket_provider.py

<li>Added new test class <code>TestBitbucketServerProvider</code><br> <li> Implemented multiple test cases for <code>get_diff_files</code> method<br> <li> Added mock implementations for Bitbucket API calls<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1172/files#diff-2956025c1e4fe6bd994cd709bc9db2acee8d211214ed0fec2a63b17ae76c8310">+200/-1</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

