### PR TITLE
feat: keep manual comments working when commenting draft MRs

### DIFF
--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -138,11 +138,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             if 'merge_request' in data:
                 mr = data['merge_request']
                 url = mr.get('url')
-                draft = mr.get('draft')
-                if draft:
-                    get_logger().info(f"Skipping draft MR: {url}")
-                    return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
-
+                
                 get_logger().info(f"A comment has been added to a merge request: {url}")
                 body = data.get('object_attributes', {}).get('note')
                 if data.get('object_attributes', {}).get('type') == 'DiffNote' and '/ask' in body: # /ask_line


### PR DESCRIPTION
### **User description**
closes #1160


___

### **PR Type**
Enhancement


___

### **Description**
- Removed the check for draft status in the GitLab webhook handler
- Allows manual comments to be processed for both draft and non-draft merge requests
- Improves user experience by enabling interaction with draft merge requests
- Addresses issue #1160



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab_webhook.py</strong><dd><code>Enable manual comments on draft merge requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/gitlab_webhook.py

<li>Removed code that skipped processing draft merge requests<br> <li> Enabled manual comments to work on draft merge requests<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1177/files#diff-c3ea1ba460930c6e6e6a2c36a7dc729d79730a96e872d40ffb246f80bc7c0880">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

