### PR TITLE
checking for publish_output in the suggestions tool exception handler

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -168,14 +168,15 @@ class PRCodeSuggestions:
                 get_logger().info('Code suggestions generated for PR, but not published since publish_output is False.')
         except Exception as e:
             get_logger().error(f"Failed to generate code suggestions for PR, error: {e}")
-            if self.progress_response:
-                self.progress_response.delete()
-            else:
-                try:
-                    self.git_provider.remove_initial_comment()
-                    self.git_provider.publish_comment(f"Failed to generate code suggestions for PR")
-                except Exception as e:
-                    pass
+            if get_settings().config.publish_output:
+                if self.progress_response:
+                    self.progress_response.delete()
+                else:
+                    try:
+                        self.git_provider.remove_initial_comment()
+                        self.git_provider.publish_comment(f"Failed to generate code suggestions for PR")
+                    except Exception as e:
+                        pass
 
     def publish_persistent_comment_with_history(self, pr_comment: str,
                                                 initial_header: str,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a check for `publish_output` configuration in the exception handler of the code suggestions tool
- Error handling and comment publishing are now only executed when `publish_output` is set to True
- This change ensures that error messages are not published when output publishing is disabled
- Improves consistency with the tool's behavior when successful



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_code_suggestions.py</strong><dd><code>Improve error handling in code suggestions tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_code_suggestions.py

<li>Added a check for <code>publish_output</code> in the exception handler<br> <li> Wrapped the error handling and comment publishing logic inside the <br><code>publish_output</code> condition<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1184/files#diff-b57ba775e741d6f80bc4f8154b71330c011dae0ac43f3d0197e785b3e6b7117b">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

