### PR TITLE
fix: change deprecated timeout parameter for litellm

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -190,7 +190,7 @@ class LiteLLMAIHandler(BaseAiHandler):
                 "deployment_id": deployment_id,
                 "messages": messages,
                 "temperature": temperature,
-                "force_timeout": get_settings().config.ai_timeout,
+                "timeout": get_settings().config.ai_timeout,
                 "api_base": self.api_base,
             }
 


### PR DESCRIPTION
### **User description**
fixed https://github.com/Codium-ai/pr-agent/issues/1187
Since the "force_timeout" parameter seems to be deprecated in litellm completion/acompletion, I changed the argument to "timeout".

I tested the code on my team's server (before/after fix) and it works.


___

### **PR Type**
Bug fix


___

### **Description**
- Updated the deprecated `force_timeout` parameter to `timeout` in the LiteLLM AI handler.
- This change addresses the issue reported in https://github.com/Codium-ai/pr-agent/issues/1187.
- The fix ensures compatibility with the latest version of LiteLLM for completion/acompletion calls.
- The change has been tested on a team server and confirmed to be working correctly.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm_ai_handler.py</strong><dd><code>Update LiteLLM timeout parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/ai_handlers/litellm_ai_handler.py

<li>Changed the deprecated <code>force_timeout</code> parameter to <code>timeout</code> in the <br><code>kwargs</code> dictionary for the chat completion function.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1189/files#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

