### PR TITLE
Fixing code suggestions being published when publish ouput is false

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -104,7 +104,8 @@ class PRCodeSuggestions:
             if not data:
                 data = {"code_suggestions": []}
 
-            if data is None or 'code_suggestions' not in data or not data['code_suggestions']:
+            if (data is None or 'code_suggestions' not in data or not data['code_suggestions'] 
+                and get_settings().config.publish_output):
                 get_logger().warning('No code suggestions found for the PR.')
                 pr_body = "## PR Code Suggestions ✨\n\nNo code suggestions found for the PR."
                 get_logger().debug(f"PR output", artifact=pr_body)


### PR DESCRIPTION
### **User description**
resolves #1188


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug where "No code suggestions" message was being published even when `publish_output` was set to false
- Added a condition to check `get_settings().config.publish_output` before publishing the message
- This change ensures that the code suggestion output is only published when explicitly configured to do so
- Resolves issue #1188



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_code_suggestions.py</strong><dd><code>Fix code suggestion publishing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_code_suggestions.py

<li>Modified the condition for logging and publishing "No code <br>suggestions" message<br> <li> Added a check for <code>get_settings().config.publish_output</code> to control <br>message publishing<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1191/files#diff-b57ba775e741d6f80bc4f8154b71330c011dae0ac43f3d0197e785b3e6b7117b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

