### PR TITLE
feat: gitlab skip source, target and labels

### DIFF
--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -112,3 +112,36 @@ LANGSMITH_API_KEY=<api_key>
 LANGSMITH_PROJECT=<project>
 LANGSMITH_BASE_URL=<url>
 ```
+
+## Ignoring automatic commands in PRs
+
+In some cases, you may want to ignore automatic commands in PRs. For example you may want to ignore MR with a specific title, or labels or from/to specific branches.
+
+For example, to ignore MRs with a specific title such as "[AUTO]: foobar", you can add the following to your `configuration.toml` file:
+
+```
+[config]
+ignore_mr_title = ["\\[AUTO\\]"]
+```
+
+Where the `ignore_mr_title` is a list of regex patterns to match the MR title you want to ignore.
+
+To ignore MRs with specific labels, you can add the following to your `configuration.toml` file:
+
+```
+[config]
+ignore_mr_labels = ["auto"]
+```
+
+Where the `ignore_mr_labels` is a list of labels you want to ignore.
+
+To ignore MRs from specific branches, you can add the following to your `configuration.toml` file:
+
+```
+[config]
+ignore_mr_source_branches = ['develop', 'main', 'master', 'stage']
+ignore_mr_target_branches = ["qa"]
+```
+
+Where the `ignore_mr_source_branches` and `ignore_mr_target_branches` are lists of regex patterns to match the source and target branches you want to ignore.
+They are not mutually exclusive, you can use them together or separately.

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -141,9 +141,32 @@ async def handle_new_pr_opened(body: Dict[str, Any],
         ignore_pr_title_re = get_settings().get("GITHUB_APP.IGNORE_PR_TITLE", [])
         if not isinstance(ignore_pr_title_re, list):
             ignore_pr_title_re = [ignore_pr_title_re]
+
         if ignore_pr_title_re and any(re.search(regex, title) for regex in ignore_pr_title_re):
             get_logger().info(f"Ignoring PR with title '{title}' due to github_app.ignore_pr_title setting")
             return {}
+
+        # logic to ignore PRs with specific labels or source branches or target branches.
+        ignore_pr_labels = get_settings().get("GITHUB_APP.IGNORE_PR_LABELS", [])
+        ignore_pr_source_branches = get_settings().get("GITHUB_APP.IGNORE_PR_SOURCE_BRANCHES", [])
+        ignore_pr_target_branches = get_settings().get("GITHUB_APP.IGNORE_PR_TARGET_BRANCHES", [])
+
+        if ignore_pr_labels:
+            labels = [label['name'] for label in pull_request.get("labels", [])]
+            if any(label in ignore_pr_labels for label in labels):
+                labels_str = ", ".join(labels)
+                get_logger().info(f"Ignoring PR with labels '{labels_str}' due to github_app.ignore_pr_labels settings")
+                return {}
+
+        if ignore_pr_source_branches or ignore_pr_target_branches:
+            source_branch = pull_request.get("head", {}).get("ref", "")
+            target_branch = pull_request.get("base", {}).get("ref", "")
+            if any(re.search(regex, source_branch) for regex in ignore_pr_source_branches):
+                get_logger().info(f"Ignoring PR with source branch '{source_branch}' due to github_app.ignore_pr_source_branches settings")
+                return {}
+            if any(re.search(regex, target_branch) for regex in ignore_pr_target_branches):
+                get_logger().info(f"Ignoring PR with target branch '{target_branch}' due to github_app.ignore_pr_target_branches settings")
+                return {}
 
         if get_identity_provider().verify_eligibility("github", sender_id, api_url) is not Eligibility.NOT_ELIGIBLE:
                 await _perform_auto_commands_github("pr_commands", agent, body, api_url, log_context)

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -138,7 +138,7 @@ async def handle_new_pr_opened(body: Dict[str, Any],
     if action in get_settings().github_app.handle_pr_actions:  # ['opened', 'reopened', 'ready_for_review']
         # logic to ignore PRs with specific titles (e.g. "[Auto] ...")
         apply_repo_settings(api_url)
-        ignore_pr_title_re = get_settings().get("GITHUB_APP.IGNORE_PR_TITLE", [])
+        ignore_pr_title_re = get_settings().get("CONFIG.IGNORE_PR_TITLE", [])
         if not isinstance(ignore_pr_title_re, list):
             ignore_pr_title_re = [ignore_pr_title_re]
 
@@ -147,9 +147,9 @@ async def handle_new_pr_opened(body: Dict[str, Any],
             return {}
 
         # logic to ignore PRs with specific labels or source branches or target branches.
-        ignore_pr_labels = get_settings().get("GITHUB_APP.IGNORE_PR_LABELS", [])
-        ignore_pr_source_branches = get_settings().get("GITHUB_APP.IGNORE_PR_SOURCE_BRANCHES", [])
-        ignore_pr_target_branches = get_settings().get("GITHUB_APP.IGNORE_PR_TARGET_BRANCHES", [])
+        ignore_pr_labels = get_settings().get("CONFIG.IGNORE_PR_LABELS", [])
+        ignore_pr_source_branches = get_settings().get("CONFIG.IGNORE_PR_SOURCE_BRANCHES", [])
+        ignore_pr_target_branches = get_settings().get("CONFIG.IGNORE_PR_TARGET_BRANCHES", [])
 
         if ignore_pr_labels:
             labels = [label['name'] for label in pull_request.get("labels", [])]

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -133,7 +133,6 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
 
             get_logger().info(f"New merge request: {url}")
 
-            # ignore draft MRs.
             if draft:
                 get_logger().info(f"Skipping draft MR: {url}")
                 return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import json
 from datetime import datetime
 
@@ -124,28 +125,47 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
         log_context["sender"] = sender
-        excluded_source_branches = get_settings().get("gitlab.excluded_source_branches", [])
-        excluded_target_branches = get_settings().get("gitlab.excluded_target_branches", [])
-        excluded_labels = get_settings().get("gitlab.excluded_labels", [])
+
         if data.get('object_kind') == 'merge_request' and data['object_attributes'].get('action') in ['open', 'reopen']:
+            title = data['object_attributes'].get('title')
             url = data['object_attributes'].get('url')
             draft = data['object_attributes'].get('draft')
-            source_branch = data['object_attributes'].get('source_branch')
-            target_branch = data['object_attributes'].get('target_branch')
-            labels = [label['title'] for label in data['object_attributes'].get('labels', [])]
 
             get_logger().info(f"New merge request: {url}")
-            if target_branch in excluded_target_branches or source_branch in excluded_source_branches:
-                get_logger().info(f"Skipping excluded branch MR: {url}")
-                return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
-            if labels.intersection(excluded_labels):
-                get_logger().info(f"Skipping excluded label MR: {url}")
-                return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
-
+            # ignore draft MRs.
             if draft:
                 get_logger().info(f"Skipping draft MR: {url}")
                 return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
+
+            # logic to ignore MRs for titles, labels and source, target branches.
+            ignore_mr_title = get_settings().get("GITLAB.IGNORE_MR_TITLE", [])
+            ignore_mr_labels = get_settings().get("GITLAB.IGNORE_MR_LABELS", [])
+            ignore_mr_source_branches = get_settings().get("GITLAB.IGNORE_MR_SOURCE_BRANCHES", [])
+            ignore_mr_target_branches = get_settings().get("GITLAB.IGNORE_MR_TARGET_BRANCHES", [])
+            if ignore_mr_source_branches:
+                source_branch = data['object_attributes'].get('source_branch')
+                if any(re.search(regex, source_branch) for regex in ignore_mr_source_branches):
+                    get_logger().info(f"Ignoring MR with source branch '{source_branch}' due to gitlab.ignore_mr_source_branches settings")
+                    return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
+
+            if ignore_mr_target_branches:
+                target_branch = data['object_attributes'].get('target_branch')
+                if any(re.search(regex, target_branch) for regex in ignore_mr_target_branches):
+                    get_logger().info(f"Ignoring MR with target branch '{target_branch}' due to gitlab.ignore_mr_target_branches settings")
+                    return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
+
+            if ignore_mr_labels:
+                labels = [label['title'] for label in data['object_attributes'].get('labels', [])]
+                if any(label in ignore_mr_labels for label in labels):
+                    labels_str = ", ".join(labels)
+                    get_logger().info(f"Ignoring MR with labels '{labels_str}' due to gitlab.ignore_mr_labels settings")
+                    return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
+
+            if ignore_mr_title:
+                if any([re.search(regex, title) for regex in ignore_mr_title]):
+                    get_logger().info(f"Ignoring MR with title '{title}' due to gitlab.ignore_mr_title settings")
+                    return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
             await _perform_commands_gitlab("pr_commands", PRAgent(), url, log_context)
         elif data.get('object_kind') == 'note' and data.get('event_type') == 'note': # comment on MR

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -139,10 +139,10 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
                 return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
             # logic to ignore MRs for titles, labels and source, target branches.
-            ignore_mr_title = get_settings().get("GITLAB.IGNORE_MR_TITLE", [])
-            ignore_mr_labels = get_settings().get("GITLAB.IGNORE_MR_LABELS", [])
-            ignore_mr_source_branches = get_settings().get("GITLAB.IGNORE_MR_SOURCE_BRANCHES", [])
-            ignore_mr_target_branches = get_settings().get("GITLAB.IGNORE_MR_TARGET_BRANCHES", [])
+            ignore_mr_title = get_settings().get("CONFIG.IGNORE_PR_TITLE", [])
+            ignore_mr_labels = get_settings().get("CONFIG.IGNORE_PR_LABELS", [])
+            ignore_mr_source_branches = get_settings().get("CONFIG.IGNORE_PR_SOURCE_BRANCHES", [])
+            ignore_mr_target_branches = get_settings().get("CONFIG.IGNORE_PR_TARGET_BRANCHES", [])
             if ignore_mr_source_branches:
                 source_branch = data['object_attributes'].get('source_branch')
                 if any(re.search(regex, source_branch) for regex in ignore_mr_source_branches):

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -132,10 +132,9 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             draft = data['object_attributes'].get('draft')
             source_branch = data['object_attributes'].get('source_branch')
             target_branch = data['object_attributes'].get('target_branch')
-            labels = data['object_attributes'].get('labels').map(lambda x: x['title'])
+            labels = [label['title'] for label in data['object_attributes'].get('labels', [])]
 
             get_logger().info(f"New merge request: {url}")
-
             if target_branch in excluded_target_branches or source_branch in excluded_source_branches:
                 get_logger().info(f"Skipping excluded branch MR: {url}")
                 return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -130,7 +130,6 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             title = data['object_attributes'].get('title')
             url = data['object_attributes'].get('url')
             draft = data['object_attributes'].get('draft')
-
             get_logger().info(f"New merge request: {url}")
 
             if draft:

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -125,7 +125,6 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
             return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
         log_context["sender"] = sender
-
         if data.get('object_kind') == 'merge_request' and data['object_attributes'].get('action') in ['open', 'reopen']:
             title = data['object_attributes'].get('title')
             url = data['object_attributes'].get('url')

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -163,7 +163,7 @@ async def gitlab_webhook(background_tasks: BackgroundTasks, request: Request):
                     return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 
             if ignore_mr_title:
-                if any([re.search(regex, title) for regex in ignore_mr_title]):
+                if any(re.search(regex, title) for regex in ignore_mr_title):
                     get_logger().info(f"Ignoring MR with title '{title}' due to gitlab.ignore_mr_title settings")
                     return JSONResponse(status_code=status.HTTP_200_OK, content=jsonable_encoder({"message": "success"}))
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -36,6 +36,15 @@ is_auto_command=false
 seed=-1 # set positive value to fix the seed (and ensure temperature=0)
 temperature=0.2
 
+# a list of regular expressions to match against the PR title to ignore the PR agent
+ignore_pr_title = []
+# a list of regular expressions of target branches to ignore from PR agent when an MR is created
+ignore_pr_target_branches = []
+# a list of regular expressions of source branches to ignore from PR agent when an MR is created
+ignore_pr_source_branches = []
+# labels to ignore from PR agent when an MR is created
+ignore_pr_labels = []
+
 [pr_reviewer] # /review #
 # enable/disable features
 require_score_review=false
@@ -187,6 +196,7 @@ base_url = "https://api.github.com"
 publish_inline_comments_fallback_with_verification = true
 try_fix_invalid_inline_comments = true
 app_name = "pr-agent"
+ignore_bot_pr = true
 
 [github_action_config]
 # auto_review = true    # set as env var in .github/workflows/pr-agent.yaml
@@ -215,16 +225,6 @@ push_commands = [
     "/describe",
     "/review --pr_reviewer.num_code_suggestions=0",
 ]
-# a list of regular expressions to match against the PR title to ignore the PR agent
-ignore_pr_title = []
-# a list of regular expressions of target branches to ignore from PR agent when an MR is created
-ignore_pr_target_branches = []
-# a list of regular expressions of source branches to ignore from PR agent when an MR is created
-ignore_pr_source_branches = []
-# labels to ignore from PR agent when an MR is created
-ignore_pr_labels = []
-# MR titles to ignore from PR agent when an MR is created
-ignore_bot_pr = true
 
 [gitlab]
 url = "https://gitlab.com"

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -230,6 +230,9 @@ push_commands = [
     "/describe",
     "/review --pr_reviewer.num_code_suggestions=0",
 ]
+excluded_target_branches = []
+excluded_source_branches = []
+excluded_labels = []
 
 [bitbucket_app]
 pr_commands = [

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -215,7 +215,15 @@ push_commands = [
     "/describe",
     "/review --pr_reviewer.num_code_suggestions=0",
 ]
+# a list of regular expressions to match against the PR title to ignore the PR agent
 ignore_pr_title = []
+# a list of regular expressions of target branches to ignore from PR agent when an MR is created
+ignore_pr_target_branches = []
+# a list of regular expressions of source branches to ignore from PR agent when an MR is created
+ignore_pr_source_branches = []
+# labels to ignore from PR agent when an MR is created
+ignore_pr_labels = []
+# MR titles to ignore from PR agent when an MR is created
 ignore_bot_pr = true
 
 [gitlab]
@@ -230,9 +238,14 @@ push_commands = [
     "/describe",
     "/review --pr_reviewer.num_code_suggestions=0",
 ]
-excluded_target_branches = []
-excluded_source_branches = []
-excluded_labels = []
+# a list of regular expressions to match against the PR title to ignore the PR agent
+ignore_mr_title = []
+# target branches to ignore from PR agent when an MR is created
+ignore_mr_target_branches = []
+# source branches to ignore from PR agent when an MR is created
+ignore_mr_source_branches = []
+# labels to ignore from PR agent when an MR is created
+ignore_mr_labels = []
 
 [bitbucket_app]
 pr_commands = [

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -238,14 +238,6 @@ push_commands = [
     "/describe",
     "/review --pr_reviewer.num_code_suggestions=0",
 ]
-# a list of regular expressions to match against the PR title to ignore the PR agent
-ignore_mr_title = []
-# target branches to ignore from PR agent when an MR is created
-ignore_mr_target_branches = []
-# source branches to ignore from PR agent when an MR is created
-ignore_mr_source_branches = []
-# labels to ignore from PR agent when an MR is created
-ignore_mr_labels = []
 
 [bitbucket_app]
 pr_commands = [


### PR DESCRIPTION
### **User description**
Related to #1190

This is a first attempt to support on the gitlab server the ability to skip automatic commands for source, target branches and labels.


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented new features to ignore PRs/MRs based on title, labels, source branches, and target branches for both GitHub and GitLab
- Added configuration options in `configuration.toml` to support these new ignore features
- Updated GitHub and GitLab webhook handlers to check for ignore conditions before processing PRs/MRs
- Added comprehensive documentation explaining how to use the new ignore features
- Moved some configuration settings to a common section for better organization
- Standardized the implementation across GitHub and GitLab platforms



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_app.py</strong><dd><code>Enhance GitHub PR filtering capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/github_app.py

<li>Moved configuration for ignoring PR titles to a common config section<br> <li> Added logic to ignore PRs with specific labels, source branches, or <br>target branches<br> <li> Implemented checks for these new ignore conditions<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1192/files#diff-3fb3f174152732d1b69953c8bd81b8a0a30f0e42100dc626d932da8371851608">+24/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gitlab_webhook.py</strong><dd><code>Implement GitLab MR filtering features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/gitlab_webhook.py

<li>Added logic to ignore merge requests based on title, labels, source <br>branches, and target branches<br> <li> Implemented checks for these new ignore conditions<br> <li> Imported 're' module for regex operations<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1192/files#diff-c3ea1ba460930c6e6e6a2c36a7dc729d79730a96e872d40ffb246f80bc7c0880">+32/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>additional_configurations.md</strong><dd><code>Document new PR/MR ignore configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/usage-guide/additional_configurations.md

<li>Added documentation for new PR/MR ignoring features<br> <li> Provided examples of how to configure ignore settings in the <br>configuration.toml file<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1192/files#diff-9290a3ad9a86690b31f0450b77acd37ef1914b41fabc8a08682d4da433a77f90">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Update configuration with new ignore options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

<li>Added new configuration options for ignoring PRs/MRs based on title, <br>labels, source branches, and target branches<br> <li> Moved some GitHub-specific settings to a common config section<br> <li> Added similar ignore settings for GitLab<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1192/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+18/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

