### PR TITLE
bug fix: remove unused get_pr_description method from Azure DevOps

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -516,12 +516,6 @@ class AzureDevopsProvider(GitProvider):
         source_branch = pr_info.source_ref_name.split("/")[-1]
         return source_branch
 
-    def get_pr_description(self, full: bool = True, split_changes_walkthrough=False) -> str:
-        max_tokens = get_settings().get("CONFIG.MAX_DESCRIPTION_TOKENS", None)
-        if max_tokens:
-            return clip_tokens(self.pr.description, max_tokens)
-        return self.pr.description
-
     def get_user_id(self):
         return 0
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed the unused `get_pr_description` method from the Azure DevOps provider class
- The method was responsible for retrieving the PR description and optionally clipping it to a maximum token length
- This change simplifies the codebase by removing unnecessary functionality
- No replacement or alternative method was added, suggesting the functionality was no longer needed



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Code cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Remove unused PR description retrieval method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

<li>Removed the <code>get_pr_description</code> method from the Azure DevOps provider <br>class<br> <li> The removed method was responsible for retrieving and potentially <br>clipping the PR description<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1210/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

