### PR TITLE
Set azure devops default status to ByDesign

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -380,7 +380,7 @@ class AzureDevopsProvider(GitProvider):
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False, thread_context=None):
         comment = Comment(content=pr_comment)
-        thread = CommentThread(comments=[comment], thread_context=thread_context, status=1)
+        thread = CommentThread(comments=[comment], thread_context=thread_context, status=5)
         thread_response = self.azure_devops_client.create_thread(
             comment_thread=thread,
             project=self.workspace_slug,


### PR DESCRIPTION
### **User description**
Using a default status of Active = 1 causes issues because a common setup is to enable comment check for Azure PRs. Setting Active=1 means that reviewers need to manually mark each comment as resolved.


Use a better ByDesign status (https://learn.microsoft.com/en-us/javascript/api/azure-devops-extension-api/commentthreadstatus), which better fits what we see in github and gitlab


___

### **PR Type**
Enhancement


___

### **Description**
- Changed the default status of Azure DevOps comment threads from Active (1) to ByDesign (5)
- This change addresses issues with common PR review setups that use comment checks
- The new ByDesign status better aligns with GitHub and GitLab behavior
- Eliminates the need for reviewers to manually mark each comment as resolved



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Update Azure DevOps comment thread default status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

<li>Changed the default status of CommentThread from 1 (Active) to 5 <br>(ByDesign)<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1228/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

