### PR TITLE
func get_line_link compatible with old gitlab versions

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -551,7 +551,7 @@ class GitLabProvider(GitProvider):
         if relevant_line_start == -1:
             link = f"{self.gl.url}/{self.id_project}/-/blob/{self.mr.source_branch}/{relevant_file}?ref_type=heads"
         elif relevant_line_end:
-            link = f"{self.gl.url}/{self.id_project}/-/blob/{self.mr.source_branch}/{relevant_file}?ref_type=heads#L{relevant_line_start}-L{relevant_line_end}"
+            link = f"{self.gl.url}/{self.id_project}/-/blob/{self.mr.source_branch}/{relevant_file}?ref_type=heads#L{relevant_line_start}-{relevant_line_end}"
         else:
             link = f"{self.gl.url}/{self.id_project}/-/blob/{self.mr.source_branch}/{relevant_file}?ref_type=heads#L{relevant_line_start}"
         return link


### PR DESCRIPTION
### **User description**
Gitlab only accept url hash like `#L{relevant_line_start}-{relevant_line_end}` before v14.1 [https://gitlab.com/gitlab-org/gitlab/-/merge_requests/65453](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/65453)

And in the gitlab documentation, it seems that the way to write it without the second `L` is more recommended. ref： [https://docs.gitlab.com/17.3/ee/user/project/repository/web_editor.html#link-to-specific-lines](https://docs.gitlab.com/17.3/ee/user/project/repository/web_editor.html#link-to-specific-lines)


___

### **PR Type**
Enhancement


___

### **Description**
- Updated the `get_line_link` method in `gitlab_provider.py` to generate URLs compatible with older GitLab versions (pre-v14.1).
- Removed the second 'L' in the URL hash for line ranges, changing from `#L{start}-L{end}` to `#L{start}-{end}`.
- This change ensures better compatibility across different GitLab versions and aligns with the recommended format in GitLab documentation.
- No other files were modified in this PR.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab_provider.py</strong><dd><code>Update GitLab URL generation for compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gitlab_provider.py

<li>Modified the <code>get_line_link</code> method to generate GitLab URLs compatible <br>with older versions<br> <li> Removed the second 'L' in the URL hash for line ranges<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1232/files#diff-35acba7a2829983fcf3c3c6a69b135988227e503ccdfa94366d1b48fcbbb0a31">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

