### PR TITLE
bug-fix_azuredevops-new-file

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -336,19 +336,22 @@ class AzureDevopsProvider(GitProvider):
                 version = GitVersionDescriptor(
                     version=base_sha.commit_id, version_type="commit"
                 )
-                try:
-                    original_file_content_str = self.azure_devops_client.get_item(
-                        repository_id=self.repo_slug,
-                        path=file,
-                        project=self.workspace_slug,
-                        version_descriptor=version,
-                        download=False,
-                        include_content=True,
-                    )
-                    original_file_content_str = original_file_content_str.content
-                except Exception as error:
-                    get_logger().error(f"Failed to retrieve original file content of {file} at version {version}", error=error)
+                if edit_type == EDIT_TYPE.ADDED:
                     original_file_content_str = ""
+                else:
+                    try:
+                        original_file_content_str = self.azure_devops_client.get_item(
+                            repository_id=self.repo_slug,
+                            path=file,
+                            project=self.workspace_slug,
+                            version_descriptor=version,
+                            download=False,
+                            include_content=True,
+                        )
+                        original_file_content_str = original_file_content_str.content
+                    except Exception as error:
+                        get_logger().error(f"Failed to retrieve original file content of {file} at version {version}", error=error)
+                        original_file_content_str = ""
 
                 patch = load_large_diff(
                     file, new_file_content_str, original_file_content_str, show_warning=False


### PR DESCRIPTION
Azure Devops PRs with new files result in error "Failed to get diff files"

## Summary
Issue: When pr-agent attempts to get the original content of a new file, a 404 is returned and pr-agent exits with an error.
Solution: Do not attempt to get original content if file `edit_type` is `ADDED`

## Reproduce Issue:
  - Configure Azure Devops git provider
  - Create any PR with a new file that is NOT in the PR source branch
  - Run pr-agent "describe"/"review"/"improve"/etc
  