### PR TITLE
Update additional_configurations.md

### DIFF
--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -160,3 +160,13 @@ ignore_pr_target_branches = ["qa"]
 
 Where the `ignore_pr_source_branches` and `ignore_pr_target_branches` are lists of regex patterns to match the source and target branches you want to ignore.
 They are not mutually exclusive, you can use them together or separately.
+
+
+To allow only specific folders (often needed in large monorepos), set:
+
+```
+[config]
+allow_only_specific_folders=['folder1','folder2']
+```
+
+For the configuration above, automatic feedback will only be triggered when the PR changes include files from 'folder1' or 'folder2'


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Added a new configuration option `allow_only_specific_folders` to the documentation.
- Explained how to use this option to trigger automatic feedback only when specific folders are changed in a PR.
- Provided an example to illustrate the configuration setup.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>additional_configurations.md</strong><dd><code>Add configuration for folder-specific PR triggers in monorepos</code></dd></summary>
<hr>

docs/docs/usage-guide/additional_configurations.md

<li>Added configuration option to allow only specific folders.<br> <li> Explained usage of <code>allow_only_specific_folders</code> in monorepos.<br> <li> Provided example configuration for folder-specific PR triggers.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1337/files#diff-9290a3ad9a86690b31f0450b77acd37ef1914b41fabc8a08682d4da433a77f90">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information