### PR TITLE
docs: add note about $CI_SERVER_FQDN variable in GitLab CI/CD pipeline

### DIFF
--- a/docs/docs/installation/gitlab.md
+++ b/docs/docs/installation/gitlab.md
@@ -38,6 +38,7 @@ You can also modify the `script` section to run different Qodo Merge commands, o
 
 Note that if your base branches are not protected, don't set the variables as `protected`, since the pipeline will not have access to them.
 
+> **Note**: The `$CI_SERVER_FQDN` variable is available starting from GitLab version 16.10. If you're using an earlier version, this variable will not be available. However, you can combine `$CI_SERVER_HOST` and `$CI_SERVER_PORT` to achieve the same result. Please ensure you're using a compatible version or adjust your configuration.
 
 
 ## Run a GitLab webhook server


### PR DESCRIPTION
### **User description**
This update adds a note to clarify the availability of the `$CI_SERVER_FQDN` variable, which was introduced in GitLab 16.10 ([docs](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)). Older GitLab versions may not have this variable, which could lead to potential configuration issues.

The change:
- Provides context for users about the `$CI_SERVER_FQDN` variable, helping to prevent confusion and troubleshooting delays for those on earlier GitLab versions.
- Adds guidance on how to achieve the same result on older versions by using `$CI_SERVER_HOST` and `$CI_SERVER_PORT` instead.


___

### **PR Type**
Documentation


___

### **Description**
- Added documentation note about the `$CI_SERVER_FQDN` variable, specifying its availability from GitLab version 16.10.
- Provided alternative configuration guidance for users on older GitLab versions using `$CI_SERVER_HOST` and `$CI_SERVER_PORT`.
- Aimed to prevent configuration issues and confusion for users on earlier GitLab versions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab.md</strong><dd><code>Add note on `$CI_SERVER_FQDN` variable in GitLab docs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/installation/gitlab.md

<li>Added a note about the <code>$CI_SERVER_FQDN</code> variable availability.<br> <li> Clarified its introduction in GitLab version 16.10.<br> <li> Provided guidance for older GitLab versions using <code>$CI_SERVER_HOST</code> and <br><code>$CI_SERVER_PORT</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1362/files#diff-568bccbe96a50a16f738f60a0c9f79e9a0c71a68bd4185281218e4aaafd24ed6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information