### PR TITLE
Add publish_output_progress config support to AzureDevOps, BitBucket and Gitlab providers

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -378,6 +378,9 @@ class AzureDevopsProvider(GitProvider):
             return []
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False, thread_context=None):
+        if is_temporary and not get_settings().config.publish_output_progress:
+            get_logger().debug(f"Skipping publish_comment for temporary comment: {pr_comment}")
+            return None
         comment = Comment(content=pr_comment)
         thread = CommentThread(comments=[comment], thread_context=thread_context, status=5)
         thread_response = self.azure_devops_client.create_thread(

--- a/pr_agent/git_providers/bitbucket_provider.py
+++ b/pr_agent/git_providers/bitbucket_provider.py
@@ -325,6 +325,9 @@ class BitbucketProvider(GitProvider):
         self.publish_comment(pr_comment)
 
     def publish_comment(self, pr_comment: str, is_temporary: bool = False):
+        if is_temporary and not get_settings().config.publish_output_progress:
+            get_logger().debug(f"Skipping publish_comment for temporary comment: {pr_comment}")
+            return None
         pr_comment = self.limit_output_characters(pr_comment, self.max_comment_length)
         comment = self.pr.comment(pr_comment)
         if is_temporary:

--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -194,6 +194,9 @@ class GitLabProvider(GitProvider):
         self.publish_persistent_comment_full(pr_comment, initial_header, update_header, name, final_update_message)
 
     def publish_comment(self, mr_comment: str, is_temporary: bool = False):
+        if is_temporary and not get_settings().config.publish_output_progress:
+            get_logger().debug(f"Skipping publish_comment for temporary comment: {mr_comment}")
+            return None
         mr_comment = self.limit_output_characters(mr_comment, self.max_comment_chars)
         comment = self.mr.notes.create({'body': mr_comment})
         if is_temporary:


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added support for the `publish_output_progress` configuration in AzureDevOps, BitBucket, and GitLab providers.
- Implemented a condition to skip publishing temporary comments if the `publish_output_progress` setting is disabled.
- Enhanced logging to provide debug information when temporary comments are skipped.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Add conditional logic for temporary comment publishing</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

<li>Added a condition to skip publishing temporary comments based on <br>configuration.<br> <li> Introduced logging for skipped temporary comments.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1376/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bitbucket_provider.py</strong><dd><code>Add conditional logic for temporary comment publishing</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/bitbucket_provider.py

<li>Added a condition to skip publishing temporary comments based on <br>configuration.<br> <li> Introduced logging for skipped temporary comments.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1376/files#diff-3f47323db85f534fa282b2d48c6cf542f00a5e791b62379253ef3d3e8c6bb3b2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gitlab_provider.py</strong><dd><code>Add conditional logic for temporary comment publishing</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gitlab_provider.py

<li>Added a condition to skip publishing temporary comments based on <br>configuration.<br> <li> Introduced logging for skipped temporary comments.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1376/files#diff-35acba7a2829983fcf3c3c6a69b135988227e503ccdfa94366d1b48fcbbb0a31">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information