### PR TITLE
Fix doc for Github Actions

### DIFF
--- a/docs/docs/usage-guide/automations_and_usage.md
+++ b/docs/docs/usage-guide/automations_and_usage.md
@@ -159,7 +159,7 @@ Specifically, start by setting the following environment variables:
         github_action_config.auto_review: "true" # enable\disable auto review
         github_action_config.auto_describe: "true" # enable\disable auto describe
         github_action_config.auto_improve: "true" # enable\disable auto improve
-        github_action_config.pr_actions: ["opened", "reopened", "ready_for_review", "review_requested"]
+        github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'
 ```
 `github_action_config.auto_review`, `github_action_config.auto_describe` and `github_action_config.auto_improve` are used to enable/disable automatic tools that run when a new PR is opened.
 If not set, the default configuration is for all three tools to run automatically when a new PR is opened.


### PR DESCRIPTION
### **User description**
A small issue I came across while customizing the Github Action workflow to trigger on custom PR actions: lists are not supported within the `env` section for Github Actions, making the suggested syntax not valid. The fix is extremely simple: the list needs to be escaped. I've already tested this and it works as expected

<img width="646" alt="image" src="https://github.com/user-attachments/assets/f61cdcdb-1b72-45f8-baaf-3a55acb50b0d">


___

### **PR Type**
documentation


___

### **Description**
- Corrected the GitHub Actions documentation by escaping a list in the `env` section to ensure valid YAML syntax.
- This change addresses an issue where lists were not supported within the `env` section, making the previous syntax invalid.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>automations_and_usage.md</strong><dd><code>Fix GitHub Actions environment variable syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/usage-guide/automations_and_usage.md

<li>Fixed syntax for <code>env</code> section in GitHub Actions documentation.<br> <li> Escaped list in <code>github_action_config.pr_actions</code> to ensure validity.<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1390/files#diff-878bb0ecba4567cf6a5fa750521c6822078e4da41864153ab50a2e236e8e9451">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information