### PR TITLE
Add support for `gemini/gemini-2.0-flash-exp` model


### DIFF
--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -42,6 +42,7 @@ MAX_TOKENS = {
     'vertex_ai/gemma2': 8200,
     'gemini/gemini-1.5-pro': 1048576,
     'gemini/gemini-1.5-flash': 1048576,
+    'gemini/gemini-2.0-flash-exp': 1048576,
     'codechat-bison': 6144,
     'codechat-bison-32k': 32000,
     'anthropic.claude-instant-v1': 100000,


### PR DESCRIPTION
### **PR Type**
Feature


___

### **PR Description**
- Added support for the new model `gemini/gemini-2.0-flash-exp` with a token limit of 1048576.
- Updated the `pr_agent/algo/__init__.py` file to include the new model in the supported models list.

