### PR TITLE
Support pull requests in personal spaces in Bitbucket Server

### DIFF
--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -402,10 +402,21 @@ class BitbucketServerProvider(GitProvider):
 
         try:
             projects_index = path_parts.index("projects")
-        except ValueError as e:
+        except ValueError:
+            projects_index = -1
+
+        try:
+            users_index = path_parts.index("users")
+        except ValueError:
+            users_index = -1
+
+        if projects_index == -1 and users_index == -1:
             raise ValueError(f"The provided URL '{pr_url}' does not appear to be a Bitbucket PR URL")
 
-        path_parts = path_parts[projects_index:]
+        if projects_index != -1:
+            path_parts = path_parts[projects_index:]
+        else:
+            path_parts = path_parts[users_index:]
 
         if len(path_parts) < 6 or path_parts[2] != "repos" or path_parts[4] != "pull-requests":
             raise ValueError(
@@ -413,6 +424,8 @@ class BitbucketServerProvider(GitProvider):
             )
 
         workspace_slug = path_parts[1]
+        if users_index != -1:
+            workspace_slug = f"~{workspace_slug}"
         repo_slug = path_parts[3]
         try:
             pr_number = int(path_parts[5])

--- a/tests/unittest/test_bitbucket_provider.py
+++ b/tests/unittest/test_bitbucket_provider.py
@@ -24,6 +24,13 @@ class TestBitbucketServerProvider:
         assert repo_slug == "my-repo"
         assert pr_number == 1
 
+    def test_parse_pr_url_with_users(self):
+        url = "https://bitbucket.company-server.url/users/username/repos/my-repo/pull-requests/1"
+        workspace_slug, repo_slug, pr_number = BitbucketServerProvider._parse_pr_url(url)
+        assert workspace_slug == "~username"
+        assert repo_slug == "my-repo"
+        assert pr_number == 1
+
     def mock_get_content_of_file(self, project_key, repository_slug, filename, at=None, markup=None):
         content_map = {
             '9c1cffdd9f276074bfb6fb3b70fbee62d298b058': 'file\nwith\nsome\nlines\nto\nemulate\na\nreal\nfile\n',


### PR DESCRIPTION
### **User description**
Related to #1148

Update `_parse_pr_url` method in `pr_agent/git_providers/bitbucket_server_provider.py` to handle URLs with `/users/`.

* Add logic to check for both `/projects/` and `/users/` in the URL path and process them accordingly.
* Modify the method to raise a `ValueError` if neither `/projects/` nor `/users/` is found in the URL.
* Update the `workspace_slug` to include a `~` prefix if the URL contains `/users/`.

Add test case for URL with `/users/` in `tests/unittest/test_bitbucket_provider.py`.

* Ensure the new test case verifies the correct parsing of URLs with `/users/`.


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for Bitbucket Server pull request URLs in personal spaces (URLs containing `/users/`)
- Enhanced URL parsing logic to handle both project-based (`/projects/`) and user-based (`/users/`) paths
- Automatically adds `~` prefix to workspace slug for personal space URLs
- Added test coverage to verify correct parsing of personal space URLs
- Eliminates the need for manual URL modification workarounds



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_server_provider.py</strong><dd><code>Enhanced PR URL parsing for personal spaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/bitbucket_server_provider.py

<li>Added support for parsing Bitbucket Server PR URLs with <code>/users/</code> path<br> <li> Modified URL parsing logic to handle both <code>/projects/</code> and <code>/users/</code> paths<br> <li> Added prefix <code>~</code> to workspace_slug when URL contains <code>/users/</code><br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1406/files#diff-c9ca96d14ab7a2935714944f8f377c4a9bb425efde19e66595bb58d33e9f5a40">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bitbucket_provider.py</strong><dd><code>Added tests for personal spaces URL parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_bitbucket_provider.py

<li>Added test case for parsing PR URLs with <code>/users/</code> path<br> <li> Verified correct handling of personal space URLs<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1406/files#diff-2956025c1e4fe6bd994cd709bc9db2acee8d211214ed0fec2a63b17ae76c8310">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information