### PR TITLE
fix: only publish empty code suggestions when configured

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -212,7 +212,7 @@ class PRCodeSuggestions:
 
     async def publish_no_suggestions(self):
         pr_body = "## PR Code Suggestions ✨\n\nNo code suggestions found for the PR."
-        if get_settings().config.publish_output:
+        if get_settings().config.publish_output and get_settings().config.publish_output_no_suggestions:
             get_logger().warning('No code suggestions found for the PR.')
             get_logger().debug(f"PR output", artifact=pr_body)
             if self.progress_response:


### PR DESCRIPTION
### **User description**
https://github.com/Codium-ai/pr-agent/issues/1404


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug where the `publish_output_no_suggestions` configuration was being ignored when publishing empty code suggestions
- Now, empty code suggestions will only be published when both `publish_output` and `publish_output_no_suggestions` are enabled



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_code_suggestions.py</strong><dd><code>Fix empty code suggestions publishing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_code_suggestions.py

<li>Added condition to check <code>publish_output_no_suggestions</code> config before <br>publishing empty code suggestions<br>


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1407/files#diff-b57ba775e741d6f80bc4f8154b71330c011dae0ac43f3d0197e785b3e6b7117b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information