### PR TITLE
fix(azure-provider): handle renamed files as new files

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -326,13 +326,13 @@ class AzureDevopsProvider(GitProvider):
                     edit_type = EDIT_TYPE.ADDED
                 elif diff_types[file] == "delete":
                     edit_type = EDIT_TYPE.DELETED
-                elif diff_types[file] == "rename":
+                elif "rename" in diff_types[file]: # diff_type can be `rename` | `edit, rename`
                     edit_type = EDIT_TYPE.RENAMED
 
                 version = GitVersionDescriptor(
                     version=base_sha.commit_id, version_type="commit"
                 )
-                if edit_type == EDIT_TYPE.ADDED:
+                if edit_type == EDIT_TYPE.ADDED or edit_type == EDIT_TYPE.RENAMED:
                     original_file_content_str = ""
                 else:
                     try:


### PR DESCRIPTION
### **User description**
This fixes a bug when azure-provider tries to fetch original content of a renamed file and fails since the file doesn't exist in base yet. Also handles case when `diff_type` includes multiple actions as `edit, rename`.

This can be improved to fetch the actual old content using the old path before renaming, but IMO for azure devops since its dying anyway, this fix should be enough.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed handling of renamed files in Azure DevOps provider.

- Addressed cases where `diff_type` includes multiple actions like `edit, rename`.

- Ensured renamed files are treated as new files for content fetching.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Fix handling of renamed files in diff processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

<li>Updated logic to handle <code>rename</code> in <code>diff_type</code>.<br> <li> Treated renamed files as new files for content fetching.<br> <li> Adjusted conditions for determining file edit type.


</details>


  </td>
  <td><a href="https://github.com/Codium-ai/pr-agent/pull/1452/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information